### PR TITLE
SCP

### DIFF
--- a/lib/sshkit/scp.ex
+++ b/lib/sshkit/scp.ex
@@ -53,7 +53,7 @@ defmodule SSHKit.SCP do
   ## Example
 
   ```
-  :ok = SSHKit.SCP.download(conn, '/var/backups', 'backups', recursive: true)
+  :ok = SSHKit.SCP.download(conn, '/home/code/sshkit', 'downloads', recursive: true)
   ```
   """
   def download(connection, remote, local, options \\ []) do

--- a/lib/sshkit/scp/download.ex
+++ b/lib/sshkit/scp/download.ex
@@ -1,6 +1,7 @@
 defmodule SSHKit.SCP.Download do
+  require Bitwise
+
   alias SSHKit.SCP.Command
-  alias SSHKit.SSH.Channel
 
   @doc """
   Downloads a file or directory from a remote host.
@@ -15,28 +16,209 @@ defmodule SSHKit.SCP.Download do
   ## Example
 
   ```
-  :ok = SSHKit.SCP.Download.transfer(conn, '/home/code/sshkit', 'downloads', recursive: true)
+  :ok = SSHKit.SCP.Download.transfer(conn, "/home/code/sshkit", "downloads", recursive: true)
   ```
   """
   def transfer(connection, remote, local, options \\ []) do
+    start(connection, remote, Path.expand(local), options)
+  end
+
+  defp start(connection, remote, local, options) do
     timeout = Keyword.get(options, :timeout, :infinity)
 
     command = Command.build(:download, remote, options)
 
-    ini = {:start, <<>>}
+    ini = {:next, local, [], %{}, <<>>, []}
 
-    handler = fn channel, message, state ->
-      IO.inspect(message)
-      ack(channel, options)
+    handler = fn message, state ->
+      case message do
+        {:data, _, 0, <<1, data :: binary>>} -> warning(options, state, data)
+        {:data, _, 0, <<2, data :: binary>>} -> fatal(options, state, data)
+        {:data, _, 0, data} ->
+          case state do
+            {:next, path, stack, attrs, buffer, errs} -> next(options, path, stack, attrs, buffer <> data, errs)
+            {:read, path, stack, attrs, buffer, errs} -> read(options, path, stack, attrs, buffer <> data, errs)
+            {:warning, state, buffer} -> warning(options, state, buffer <> data)
+            {:fatal, state, buffer} -> fatal(options, state, buffer <> data)
+          end
+        {:exit_status, _, status} -> exited(options, state, status)
+        {:eof, _} -> eof(options, state)
+        {:closed, _} -> closed(options, state)
+     end
     end
 
-    {:ok, channel} = SSHKit.SSH.start(connection, command, timeout)
-    :ok = Channel.send(channel, 0, <<0>>, timeout)
-    SSHKit.SSH.Channel.loop(channel, timeout, ini, handler)
+    SSHKit.SSH.run(connection, command, timeout: timeout, acc: {:cont, <<0>>, ini}, fun: handler)
   end
 
-  defp ack(channel, _) do
-    :ok = Channel.send(channel, <<0>>)
-    {:next, <<>>}
+  defp next(options, path, stack, attrs, buffer, errs) do
+    if String.last(buffer) == "\n" do
+      case dirparse(buffer) do
+        {"T", mtime, _, atime, _} -> time(options, path, stack, attrs, mtime, atime, errs)
+        {"C", mode, len, name} -> regular(options, path, stack, attrs, mode, len, name, errs)
+        {"D", mode, _, name} -> directory(options, path, stack, attrs, mode, name, errs)
+        {"E"} -> up(options, path, stack, errs)
+        _ -> {:halt, {:error, "Invalid SCP directive received: #{buffer}"}}
+      end
+    else
+      {:cont, {:next, stack, buffer, attrs}}
+    end
   end
+
+  defp time(_, path, stack, attrs, mtime, atime, errs) do
+    attrs = Map.merge(attrs, %{atime: atime, mtime: mtime})
+    {:cont, <<0>>, {:next, path, stack, attrs, <<>>, errs}}
+  end
+
+  defp directory(options, path, stack, attrs, mode, name, errs) do
+    target = if File.dir?(path), do: Path.join(path, name), else: path
+
+    preserve? = Keyword.get(options, :preserve, false)
+    exists? = File.exists?(target)
+
+    stat = if exists?, do: File.stat!(target), else: nil
+
+    if exists? do
+      :ok = File.chmod!(target, Bitwise.bor(stat.mode, 0o700))
+    else
+      :ok = File.mkdir!(target)
+    end
+
+    mode = if exists? && !preserve?, do: stat.mode, else: mode
+    attrs = Map.put(attrs, :mode, mode)
+
+    {:cont, <<0>>, {:next, target, [attrs | stack], %{}, <<>>, errs}}
+  end
+
+  defp regular(options, path, stack, attrs, mode, length, name, errs) do
+    target = if File.dir?(path), do: Path.join(path, name), else: path
+
+    preserve? = Keyword.get(options, :preserve, false)
+    exists? = File.exists?(target)
+
+    stat = if exists?, do: File.stat!(target), else: nil
+
+    if exists? do
+      :ok = File.chmod!(target, Bitwise.bor(stat.mode, 0o200))
+    end
+
+    device = File.open!(target, [:write, :binary])
+
+    mode = if exists? && !preserve?, do: stat.mode, else: mode
+
+    attrs =
+      attrs
+      |> Map.put(:mode, mode)
+      |> Map.put(:device, device)
+      |> Map.put(:length, length)
+      |> Map.put(:written, 0)
+
+    {:cont, <<0>>, {:read, target, stack, attrs, <<>>, errs}}
+  end
+
+  defp read(options, path, stack, attrs, buffer, errs) do
+    %{device: device, length: length, written: written} = attrs
+
+    {buffer, written} =
+      if written < length do
+        count = min(byte_size(buffer), length - written)
+        <<chunk::binary-size(count), rest::binary>> = buffer
+        :ok = IO.binwrite(device, chunk)
+        {rest, written + count}
+      else
+        {buffer, written}
+      end
+
+    if written == length && buffer == <<0>> do
+      :ok = File.close(device)
+
+      :ok = File.chmod!(path, attrs[:mode])
+
+      if Keyword.get(options, :preserve, false) do
+        :ok = touch!(path, attrs[:atime], attrs[:mtime])
+      end
+
+      {:cont, <<0>>, {:next, Path.dirname(path), stack, %{}, <<>>, errs}}
+    else
+      {:cont, {:read, path, stack, Map.put(attrs, :written, written), <<>>, errs}}
+    end
+  end
+
+  defp up(options, path, [attrs | rest], errs) do
+    :ok = File.chmod!(path, attrs[:mode])
+
+    if Keyword.get(options, :preserve, false) do
+      :ok = touch!(path, attrs[:atime], attrs[:mtime])
+    end
+
+    {:cont, <<0>>, {:next, Path.dirname(path), rest, %{}, <<>>, errs}}
+  end
+
+  defp exited(_, {_, _, [], _, _, errs}, status) do
+    {:cont, {:done, status, errs}}
+  end
+
+  defp exited(_, {_, _, _, _, _, errs}, status) do
+    {:halt, {:error, "SCP exited before completing the transfer (#{status}): #{Enum.join(errs, ", ")}"}}
+  end
+
+  defp eof(_, state) do
+    {:cont, state}
+  end
+
+  defp closed(_, {:done, 0, _}) do
+    {:cont, :ok}
+  end
+
+  defp closed(_, {:done, status, errs}) do
+    {:cont, {:error, "SCP exited with non-zero exit code #{status}: #{Enum.join(errs, ", ")}"}}
+  end
+
+  defp closed(_, _) do
+    {:cont, {:error, "SCP channel closed before completing the transfer"}}
+  end
+
+  defp warning(_, {name, path, stack, attrs, buf, errs} = state, buffer) do
+    if String.last(buffer) == "\n" do
+      {:cont, {name, path, stack, attrs, buf, errs ++ [String.trim(buffer)]}}
+    else
+      {:cont, {:warning, state, buffer}}
+    end
+  end
+
+  defp fatal(_, state, buffer) do
+    if String.last(buffer) == "\n" do
+      {:halt, {:error, String.trim(buffer)}}
+    else
+      {:cont, {:fatal, state, buffer}}
+    end
+  end
+
+  @epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+
+  defp touch!(path, atime, mtime) do
+    atime = :calendar.gregorian_seconds_to_datetime(@epoch + atime)
+    mtime = :calendar.gregorian_seconds_to_datetime(@epoch + mtime)
+    :ok = :file.change_time(path, atime, mtime)
+  end
+
+  @tfmt ~S"(T)(0|[1-9]\d*) (0|[1-9]\d{0,5}) (0|[1-9]\d*) (0|[1-9]\d{0,5})"
+  @ffmt ~S"(C|D)([0-7]{4}) (0|[1-9]\d*) ([^/]+)"
+  @efmt ~S"(E)"
+
+  @dfmt ~r/\A(?|#{@efmt}|#{@tfmt}|#{@ffmt})\n\z/
+
+  defp dirparse(value) do
+    case Regex.run(@dfmt, value, capture: :all_but_first) do
+      ["T", mtime, mtus, atime, atus] -> {"T", dec(mtime), dec(mtus), dec(atime), dec(atus)}
+      [chr, _, _, name] when chr in ["C", "D"] and name in ["/", "..", "."] -> nil
+      ["C", mode, len, name] -> {"C", oct(mode), dec(len), name}
+      ["D", mode, len, name] -> {"D", oct(mode), dec(len), name}
+      ["E"] -> {"E"}
+      nil -> nil
+    end
+  end
+
+  defp int(value, base), do: String.to_integer(value, base)
+  defp dec(value), do: int(value, 10)
+  defp oct(value), do: int(value, 8)
 end

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -77,7 +77,7 @@ defmodule SSHKit.SCP.Upload do
   end
 
   defp time(channel, _, type, name, stat, cwd, stack) do
-    :ok = Channel.send(channel, 'T#{mtime} 0 #{atime} 0\n')
+    :ok = Channel.send(channel, 'T#{stat.mtime} 0 #{stat.atime} 0\n')
     {type, name, stat, cwd, stack}
   end
 
@@ -91,7 +91,7 @@ defmodule SSHKit.SCP.Upload do
     {:data, name, stat, cwd, stack}
   end
 
-  defp data(channel, _, name, stat, cwd, stack) do
+  defp data(channel, _, name, _, cwd, stack) do
     File.stream!(Path.join(cwd, name), [], 16_384)
     |> Enum.each(fn data -> :ok = Channel.send(channel, data) end)
 

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -39,6 +39,8 @@ defmodule SSHKit.SCP.Upload do
 
     handler = fn message, state ->
       case message do
+        {:data, _, 0, <<1, data :: binary>>} -> warning(options, state, data)
+        {:data, _, 0, <<2, data :: binary>>} -> fatal(options, state, data)
         {:data, _, 0, <<0>>} ->
           case state do
             {:next, cwd, stack, errs} -> next(options, cwd, stack, errs)
@@ -46,12 +48,10 @@ defmodule SSHKit.SCP.Upload do
             {:regular, name, stat, cwd, stack, errs} -> regular(options, name, stat, cwd, stack, errs)
             {:write, name, stat, cwd, stack, errs} -> write(options, name, stat, cwd, stack, errs)
           end
-        {:data, _, 0, <<1, msg :: binary>>} -> warning(options, state, msg)
-        {:data, _, 0, <<2, msg :: binary>>} -> fatal(options, state, msg)
-        {:data, _, 0, msg} ->
+        {:data, _, 0, data} ->
           case state do
-            {:warning, state, buffer} -> warning(options, state, buffer <> msg)
-            {:fatal, state, buffer} -> fatal(options, state, buffer <> msg)
+            {:warning, state, buffer} -> warning(options, state, buffer <> data)
+            {:fatal, state, buffer} -> fatal(options, state, buffer <> data)
           end
         {:exit_status, _, status} -> exited(options, state, status)
         {:eof, _} -> eof(options, state)

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -2,7 +2,6 @@ defmodule SSHKit.SCP.Upload do
   require Bitwise
 
   alias SSHKit.SCP.Command
-  alias SSHKit.SSH.Channel
 
   @doc """
   Uploads a local file or directory to a remote host.
@@ -27,99 +26,97 @@ defmodule SSHKit.SCP.Upload do
 
     ini = {:next, ".", [[local]]}
 
-    handler = fn channel, message, state ->
+    handler = fn message, state ->
       case message do
-        {:data, 0, <<0>>} ->
+        {:data, _, 0, <<0>>} ->
           case state do
-            {:next, cwd, stack} -> next(channel, options, cwd, stack)
-            {:directory, name, stat, cwd, stack} -> directory(channel, options, name, stat, cwd, stack)
-            {:file, name, stat, cwd, stack} -> file(channel, options, name, stat, cwd, stack)
-            {:data, name, stat, cwd, stack} -> data(channel, options, name, stat, cwd, stack)
-            {:done, status} -> done(channel, options, status)
+            {:next, cwd, stack} -> next(options, cwd, stack)
+            {:directory, name, stat, cwd, stack} -> directory(options, name, stat, cwd, stack)
+            {:file, name, stat, cwd, stack} -> file(options, name, stat, cwd, stack)
+            {:data, name, stat, cwd, stack} -> data(options, name, stat, cwd, stack)
+            {:done, status} -> done(options, status)
           end
-        {:data, 0, <<1, msg :: binary>>} -> warning(channel, options, state, msg)
-        {:data, 0, <<2, msg :: binary>>} -> fatal(channel, options, state, msg)
-        {:data, 0, msg} ->
+        {:data, _, 0, <<1, msg :: binary>>} -> warning(options, state, msg)
+        {:data, _, 0, <<2, msg :: binary>>} -> fatal(options, state, msg)
+        {:data, _, 0, msg} ->
           case state do
-            {:warning, state, buffer} -> warning(channel, options, state, buffer <> msg)
-            {:fatal, state, buffer} -> fatal(channel, options, state, buffer <> msg)
+            {:warning, state, buffer} -> warning(options, state, buffer <> msg)
+            {:fatal, state, buffer} -> fatal(options, state, buffer <> msg)
           end
-        {:exit_status, status} -> exited(channel, options, status)
-        {:eof} -> state
-        {:closed} -> state
+        {:exit_status, _, status} -> exited(options, status)
+        {:eof, _} -> cont(state)
+        {:closed, _} -> cont(state)
       end
     end
 
-    SSHKit.SSH.run(connection, command, timeout, ini, handler)
+    SSHKit.SSH.run(connection, command, timeout: timeout, acc: {:cont, ini}, fun: handler)
   end
 
-  defp next(channel, _, ".", []) do
-    :ok = Channel.eof(channel)
-    {:cont, {:done, nil}}
+  defp next(_, ".", []) do
+    {:cont, :eof, {:done, nil}}
   end
 
-  defp next(channel, _, cwd, [[] | dirs]) do
-    :ok = Channel.send(channel, 'E\n')
-    {:cont, {:next, Path.dirname(cwd), dirs}}
+  defp next(_, cwd, [[] | dirs]) do
+    {:cont, 'E\n', {:next, Path.dirname(cwd), dirs}}
   end
 
-  defp next(channel, options, cwd, [[name | rest] | dirs]) do
+  defp next(options, cwd, [[name | rest] | dirs]) do
     path = Path.join(cwd, name)
     stat = File.stat!(path, time: :posix)
 
     case stat.type do
-      :directory -> directory(channel, options, name, stat, cwd, [File.ls!(path) | [rest | dirs]])
-      :regular -> file(channel, options, name, stat, cwd, [rest | dirs])
+      :directory -> directory(options, name, stat, cwd, [File.ls!(path) | [rest | dirs]])
+      :regular -> file(options, name, stat, cwd, [rest | dirs])
     end
   end
 
-  defp time(channel, _, type, name, stat, cwd, stack) do
-    :ok = Channel.send(channel, 'T#{stat.mtime} 0 #{stat.atime} 0\n')
-    {:cont, {type, name, stat, cwd, stack}}
+  defp time(_, type, name, stat, cwd, stack) do
+    directive = 'T#{stat.mtime} 0 #{stat.atime} 0\n'
+    {:cont, directive, {type, name, stat, cwd, stack}}
   end
 
-  defp directory(channel, _, name, stat, cwd, stack) do
-    :ok = Channel.send(channel, 'D#{modefmt(stat.mode)} 0 #{name}\n')
-    {:cont, {:next, Path.join(cwd, name), stack}}
+  defp directory(_, name, stat, cwd, stack) do
+    directive = 'D#{modefmt(stat.mode)} 0 #{name}\n'
+    {:cont, directive, {:next, Path.join(cwd, name), stack}}
   end
 
-  defp file(channel, _, name, stat, cwd, stack) do
-    :ok = Channel.send(channel, 'C#{modefmt(stat.mode)} #{stat.size} #{name}\n')
-    {:cont, {:data, name, stat, cwd, stack}}
+  defp file(_, name, stat, cwd, stack) do
+    directive = 'C#{modefmt(stat.mode)} #{stat.size} #{name}\n'
+    {:cont, directive, {:data, name, stat, cwd, stack}}
   end
 
-  defp data(channel, _, name, _, cwd, stack) do
-    File.stream!(Path.join(cwd, name), [], 16_384)
-    |> Enum.each(fn data -> :ok = Channel.send(channel, data) end)
-
-    :ok = Channel.send(channel, <<0>>)
-
-    {:cont, {:next, cwd, stack}}
+  defp data(_, name, _, cwd, stack) do
+    fs = File.stream!(Path.join(cwd, name), [], 16_384)
+    {:cont, Stream.concat(fs, [<<0>>]), {:next, cwd, stack}}
   end
 
-  defp exited(_, _, status) do
+  defp exited(_, status) do
     {:cont, {:done, status}}
   end
 
-  defp done(_, _, 0) do
+  defp done(_, 0) do
     {:cont, :ok}
   end
 
-  defp done(_, _, status) do
+  defp done(_, status) do
     {:cont, {:error, "SCP exited with a non-zero exit code (#{status})"}}
   end
 
-  defp warning(channel, options, state, buffer) do
-    error(channel, options, :warning, state, buffer)
+  defp cont(state) do
+    {:cont, state}
   end
 
-  defp fatal(channel, options, state, buffer) do
-    error(channel, options, :fatal, state, buffer)
+  defp warning(options, state, buffer) do
+    error(options, :warning, state, buffer)
   end
 
-  defp error(_, _, type, state, buffer) do
+  defp fatal(options, state, buffer) do
+    error(options, :fatal, state, buffer)
+  end
+
+  defp error(_, type, state, buffer) do
     if String.last(buffer) == "\n" do
-      {:stop, {:error, String.trim(buffer)}}
+      {:halt, {:error, String.trim(buffer)}}
     else
       {:cont, {type, state, buffer}}
     end

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -23,7 +23,7 @@ defmodule SSHKit.SCP.Upload do
   def transfer(connection, local, remote, options \\ []) do
     timeout = Keyword.get(options, :timeout, :infinity)
 
-    cmd = Command.build(:upload, remote, options)
+    command = Command.build(:upload, remote, options)
 
     ini = {:next, ".", [[local]]}
 
@@ -53,7 +53,7 @@ defmodule SSHKit.SCP.Upload do
       end
     end
 
-    SSHKit.SSH.run(connection, cmd, timeout, ini, handler)
+    SSHKit.SSH.run(connection, command, timeout, ini, handler)
   end
 
   defp next(channel, _, ".", []) do

--- a/lib/sshkit/ssh.ex
+++ b/lib/sshkit/ssh.ex
@@ -10,14 +10,11 @@ defmodule SSHKit.SSH do
   {:ok, output, status} = SSHKit.SSH.run(conn, 'uptime')
   :ok = SSHKit.SSH.close(conn)
 
-  log = fn {type, data} ->
-    case type do
-      :normal -> IO.write(data)
-      :stderr -> IO.write([IO.ANSI.red, data, IO.ANSI.reset])
-    end
-  end
+  Enum.each(output, fn
+    {:normal, data} -> IO.write(data)
+    {:stderr, data} -> IO.write([IO.ANSI.red, data, IO.ANSI.reset])
+  end)
 
-  Enum.each(output, log)
   IO.puts("$?: #{status}")
   ```
   """

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -13,20 +13,18 @@ defmodule SSHKit.SSH.Channel do
 
   ## Options
 
-  * `:type` - the type of the channel, defaults to `:session`
   * `:timeout` - defaults to `:infinity`
   * `:initial_window_size` - defaults to 128 KiB
   * `:max_packet_size` - defaults to 32 KiB
   """
   def open(connection, options \\ []) do
-    type = Keyword.get(options, :type, :session)
     timeout = Keyword.get(options, :timeout, :infinity)
     ini_window_size = Keyword.get(options, :initial_window_size, 128 * 1024)
     max_packet_size = Keyword.get(options, :max_packet_size, 32 * 1024)
 
     case :ssh_connection.session_channel(connection.ref, ini_window_size, max_packet_size, timeout) do
-      {:ok, id} -> {:ok, %Channel{connection: connection, type: type, id: id}}
-      other -> other
+      {:ok, id} -> {:ok, %Channel{connection: connection, type: :session, id: id}}
+      err -> err
     end
   end
 
@@ -60,12 +58,20 @@ defmodule SSHKit.SSH.Channel do
   @doc """
   Sends data across an open SSH channel.
 
+  `data` may be an enumerable, e.g. a `File.Stream` or `IO.Stream`.
+
   Returns `:ok`, `{:error, :timeout}` or `{:error, :closed}`.
 
   For more details, see [`:ssh_connection.send/5`](http://erlang.org/doc/man/ssh_connection.html#send-5).
   """
-  def send(channel, type \\ 0, data, timeout \\ :infinity) do
+  def send(channel, type \\ 0, data, timeout \\ :infinity)
+
+  def send(channel, type, data, timeout) when is_binary(data) or is_list(data) do
     :ssh_connection.send(channel.connection.ref, channel.id, type, data, timeout)
+  end
+
+  def send(channel, type, data, timeout) do
+    Enum.each(data, fn datum -> :ok = send(channel, type, datum, timeout) end)
   end
 
   @doc """
@@ -84,19 +90,20 @@ defmodule SSHKit.SSH.Channel do
 
   Returns `{:ok, message}` or `{:error, :timeout}`.
 
-  For more details, see [`:ssh_connection`](http://erlang.org/doc/man/ssh_connection.html).
+  Only listens to messages from the channel specified as the first argument.
 
   ## Messages
 
   The message tuples returned by `recv/3` correspond to the underlying Erlang
-  channel messages with the channel id stripped. `recv` only listens to
-  messages from the channel specified as the first argument.
+  channel messages with the channel id replaced by the SSHKit channel struct:
 
-  * `{:data, type, data}` - data has arrived, `type` is 0 "normal" or 1 "stderr"
-  * `{:eof}` - indicates that no more data is to be sent by the remote process
-  * `{:exit_signal, signal, msg, lang}` - remote execution terminated by `signal`
-  * `{:exit_status, status}` - remote command terminated with exit code `status`
-  * `{:closed}` - indicates that the channel has now been shut down
+  * `{:data, channel, type, data}`
+  * `{:eof, channel}`
+  * `{:exit_signal, channel, signal, msg, lang}`
+  * `{:exit_status, channel, status}`
+  * `{:closed, channel}`
+
+  For more details, see [`:ssh_connection`](http://erlang.org/doc/man/ssh_connection.html).
   """
   def recv(channel, timeout \\ :infinity) do
     ref = channel.connection.ref
@@ -104,50 +111,114 @@ defmodule SSHKit.SSH.Channel do
 
     receive do
       {:ssh_cm, ^ref, msg} when elem(msg, 1) == id ->
-        {:ok, Tuple.delete_at(msg, 1)}
+        msg = msg |> Tuple.delete_at(1) |> Tuple.insert_at(1, channel)
+        {:ok, msg}
     after
-      timeout ->
-        {:error, :timeout}
+      timeout -> {:error, :timeout}
     end
   end
 
   @doc """
-  Loops over channel messages until the channel is closed, or looping is
-  stopped explicitly.
+  Adjusts the flow control window.
 
-  Invokes `fun` for each channel message, passing the channel, message and
-  `state` as arguments. `fun`'s return value must be a tagged tuple:
+  Returns `:ok`.
 
-  - `{:cont, term}` - stores `term` in `state` for the next call to `fun`
-  - `{:stop, term}` - stops the loop, which will return `{:stopped, term}`
-
-  `timeout` specifies the maximum delay between two subsequent messages.
-
-  Returns `{:done, state}` after the channel is closed and the close message
-  has been handled. Returns `{:stopped, state}` if the loop was stopped early.
-  Returns `{:error, :timeout}` if a message was not received in time.
+  For more details, see [`:ssh_connection.adjust_window/3`](http://erlang.org/doc/man/ssh_connection.html#adjust_window-3).
   """
-  def loop(channel, timeout \\ :infinity, state \\ nil, fun) do
-    case recv(channel, timeout) do
-      {:ok, message} ->
-        ref = channel.connection.ref
-        id = channel.id
+  def adjust(channel, size) when is_integer(size) do
+    :ssh_connection.adjust_window(channel.connection.ref, channel.id, size)
+  end
 
-        case message do
-          {:data, _, data} -> :ssh_connection.adjust_window(ref, id, byte_size(data))
-          _ -> :ok
-        end
+  @doc """
+  Loops over channel messages until the channel is closed, or looping is stopped
+  explicitly.
 
-        case fun.(channel, message, state) do
-          {:cont, state} ->
-            if message == {:closed} do
-              {:done, state}
-            else
-              loop(channel, timeout, state, fun)
-            end
-          {:stop, state} -> {:stopped, state}
-        end
-      {:error, :timeout} -> {:error, :timeout}
+  Expects an accumulator on each call that determines how to proceed:
+
+  1. `{:cont, state}`
+
+    The loop will wait for an inbound message. It will then pass the message and
+    current `state` to the looping function. `fun`'s return value is the
+    accumulator for the next cycle.
+
+  2. `{:cont, message, state}`
+
+    Sends a message to the remote end of the channel before waiting for a
+    message as outlined in the `{:cont, state}` case above. `message` may be one
+    of the following:
+
+      * `{0, data}` or `{1, data}` - sends normal or stderr data to the remote
+      * `data` - is a shortcut for `{0, data}`
+      * `:eof` - sends EOF
+
+  3. `{:halt, state}`
+
+    Terminates the loop, returning `{:halted, state}`.
+
+  4. `{:suspend, state}`
+
+    Suspends the loop, returning `{:suspended, state, continuation}`.
+    `continuation` is a function that accepts a new accumulator value and that,
+    when called, will resume the loop.
+
+  `timeout` specifies the maximum wait time for receiving and sending individual
+  messages.
+
+  Once the final `{:closed, channel}` message is received, the loop will
+  terminate and return `{:done, state}`. The channel will be closed if it has
+  not been closed before.
+  """
+  def loop(channel, timeout \\ :infinity, acc, fun)
+
+  def loop(channel, timeout, {:cont, msg, acc}, fun) do
+    case lsend(channel, msg, timeout) do
+      :ok -> loop(channel, timeout, {:cont, acc}, fun)
+      err -> halt(channel, err)
     end
   end
+
+  def loop(channel, timeout, {:cont, acc}, fun) do
+    case recv(channel, timeout) do
+      {:ok, msg} ->
+        if elem(msg, 0) == :closed do
+          {_, acc} = fun.(msg, acc)
+          {:done, acc}
+        else
+          :ok = ljust(channel, msg)
+          loop(channel, timeout, fun.(msg, acc), fun)
+        end
+      err -> halt(channel, err)
+    end
+  end
+
+  def loop(channel, _, {:halt, acc}, _) do
+    halt(channel, acc)
+  end
+
+  def loop(channel, timeout, {:suspend, acc}, fun) do
+    {:suspended, acc, &loop(channel, timeout, &1, fun)}
+  end
+
+  defp halt(channel, acc) do
+    :ok = close(channel)
+    {:halted, acc}
+  end
+
+  defp lsend(_, nil, _), do: :ok
+
+  defp lsend(channel, :eof, _), do: eof(channel)
+
+  defp lsend(channel, {type, data}, timeout) do
+    send(channel, type, data, timeout)
+  end
+
+  defp lsend(channel, data, timeout) do
+    send(channel, 0, data, timeout)
+  end
+
+  defp ljust(channel, {:data, _, _, data}) do
+    adjust(channel, byte_size(data))
+  end
+
+  defp ljust(_, _), do: :ok
 end

--- a/lib/sshkit/ssh/connection.ex
+++ b/lib/sshkit/ssh/connection.ex
@@ -33,7 +33,7 @@ defmodule SSHKit.SSH.Connection do
 
     case :ssh.connect(host, port, options, timeout) do
       {:ok, ref} -> {:ok, %Connection{host: host, port: port, options: options, ref: ref}}
-      other -> other
+      err -> err
     end
   end
 
@@ -52,7 +52,7 @@ defmodule SSHKit.SSH.Connection do
   Opens a new connection, based on the parameters of an existing one.
 
   The timeout value of the original connection is discarded.
-  Other connection options are reused and may be overriden.
+  Other connection options are reused and may be overridden.
 
   Uses `SSHKit.SSH.open/2`.
 

--- a/lib/sshkit/ssh/connection.ex
+++ b/lib/sshkit/ssh/connection.ex
@@ -42,7 +42,7 @@ defmodule SSHKit.SSH.Connection do
 
   Returns `:ok`.
 
-  For details, see [`:ssh_connection.close/2`](http://erlang.org/doc/man/ssh_connection.html#close-2).
+  For details, see [`:ssh.close/1`](http://erlang.org/doc/man/ssh.html#close-1).
   """
   def close(connection) do
     :ssh.close(connection.ref)


### PR DESCRIPTION
SCP recursive uploads are implemented. However they're a little rough around the edges still. Downloads are still missing.

Open points:

- they'll always recursively upload directories even if the `recursive: true` options was not specified
  - maybe return an error here
- download needs to be done still, will likely look similar in terms of connection handling/messages
- functional tests
  - run docker containers with actual sshd running
  - for uploads and downloads (downloads to a tmp dir)
  - assert content, structure, file mode, timestamps…

References:

- https://blogs.oracle.com/janp/entry/how_the_scp_protocol_works