### PR TITLE
[#16] Set up continuous integration checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 # The directory Mix downloads your dependencies sources to.
 /deps
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
+# Where 3rd-party dependencies like ExDoc and InchEx output generated docs.
+/docs
 /doc
 
 # If the VM crashes, it generates a dump, let's ignore it too.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: elixir
+elixir:
+  - 1.3
+  - 1.4
+script:
+  # TODO: Fix existing issues and enable credo code checks
+  # - mix credo --strict
+  - mix test
+after_script:
+  - mix inch.report

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SSHKit
 
-[![Inline docs](http://inch-ci.org/github/bitcrowd/sshkit.ex.svg)](http://inch-ci.org/github/bitcrowd/sshkit.ex)
+[![Build Status](https://travis-ci.org/bitcrowd/sshkit.ex.svg?branch=master)](https://travis-ci.org/bitcrowd/sshkit.ex)
+[![Inline docs](http://inch-ci.org/github/bitcrowd/sshkit.ex.svg?branch=master)](http://inch-ci.org/github/bitcrowd/sshkit.ex)
 
 SSHKit is an Elixir toolkit for performing tasks on one or more servers,
 built on top of Erlang’s SSH application.

--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,8 @@ defmodule SSHKit.Mixfile do
 
   defp deps do
     [{:credo, "~> 0.7", only: [:dev, :test]},
-     {:ex_doc, "~> 0.14", only: [:dev]},
-     {:inch_ex, ">= 0.0.0", only: [:dev]}]
+     {:ex_doc, "~> 0.14", only: [:dev], runtime: false},
+     {:inch_ex, "~> 0.5", only: [:dev, :test]}]
   end
 
   defp description do


### PR DESCRIPTION
Adds a `.travis.yml` running:

- `mix credo --strict`
- `mix test`, and
- `mix inch.report` (after the tests)

Pull-request to add `bitcrowd/sshkit.ex` to [Inch CI](https://inch-ci.org/github/bitcrowd/sshkit.ex) is here: https://github.com/rrrene/inch_ex/pull/46