### PR TITLE
Allow upload of larger files

### DIFF
--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -62,7 +62,7 @@ defmodule SSHKit.SCP.Upload do
     SSHKit.SSH.run(connection, command, timeout: timeout, acc: {:cont, ini}, fun: handler)
   end
 
-  defp next(_, _, [], errs) do
+  defp next(_, _, [[]], errs) do
     {:cont, :eof, {:done, nil, errs}}
   end
 


### PR DESCRIPTION
Fixes the pattern match so that an `:eof` is correctly returned for larger file uploads.

Fixes #30 