### PR TITLE
[#46] Add documentation for the basic SSHKit DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ context =
 :ok = SSHKit.run(context, "yarn install")
 ```
 
-The [`SSHKit`](https://hexdocs.pm/sshkit/SSHKit.html#content) module documentation has more guidance and examples for the DSL.
+The [`SSHKit`](https://hexdocs.pm/sshkit/SSHKit.html) module documentation has more guidance and examples for the DSL.
 If you need more control, take a look at the `SSHKit.SSH` and `SSHKit.SCP`
 modules.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ context =
 :ok = SSHKit.run(context, "yarn install")
 ```
 
+The [`SSHKit`](https://hexdocs.pm/sshkit/SSHKit.html#content) module documentation has more guidance and examples for the DSL.
 If you need more control, take a look at the `SSHKit.SSH` and `SSHKit.SCP`
 modules.
 

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -25,39 +25,27 @@ defmodule SSHKit do
   alias SSHKit.Host
 
   @doc """
-  Produces a SSHKit.Host struct holding the information
+  Produces a `SSHKit.Host` struct holding the information
   needed to connect to a (remote) host.
 
-  ## Example
+  ## Examples
 
-  There a many ways to create an SSHKit host:
-
-  ```
-  host = SSHKit.host(%{name: "me.fancy_domain.io", options: [port: 3000]})
-  ```
-
-  or
+  In its most basic version, you just pass a hostname and all other options will use the defaults:
 
   ```
-  host = SSHKit.host({"me.fancy_domain.io", [port: 3000]})
+  host = SSHKit.host("name.io")
   ```
 
-  or
+  If you wish to provide additional host options, e.g. a non-standard port, you can pass a second argument:
 
   ```
-  host = SSHKit.host({"me.fancy_domain.io", [port: 3000]})
+  host = SSHKit.host(name: "name.io", port: 2222)
   ```
 
-  or
+  … or, alternatively, a tuple with hostname and options:
 
   ```
-  host = SSHKit.host("10.0.0.1")
-  ```
-
-  or
-
-  ```
-  host = SSHKit.host("10.0.0.1", port: 3000)
+  host = SSHKit.host({"name.io", port: 2222})
   ```
 
   One or many of these hosts can then be used
@@ -133,7 +121,7 @@ defmodule SSHKit do
 
   @doc """
   Changes the umask affecting default file/directory
-  permission.
+  permissions.
   It returns the modified context for easy chaining.
 
   ## Example
@@ -152,7 +140,7 @@ defmodule SSHKit do
   end
 
   @doc """
-  Specifies the user under whose name commands are executed at.
+  Specifies the user under whose name commands are executed.
   That user might be different than the user with which
   ssh connects to the remote host.
   It returns the modified context for easy chaining.
@@ -226,12 +214,10 @@ defmodule SSHKit do
 
   @doc ~S"""
   Executes a command within the given context.
-  Returns a list of tuples of the form `{:ok, output, return_code}`.
+  Returns a list of tuples of the form `{:ok, output, exit_code}`.
   There is one tuple per connected host a command was executed at.
 
-  ## Parameters
-
-  * `return_code` is the number with which the executed command returns.
+  * `exit_code` is the number with which the executed command returns.
     If things went well, that usually is `0`.
 
   * `output` is a keyword list of the commands collected output.

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -24,14 +24,52 @@ defmodule SSHKit do
   alias SSHKit.Context
   alias SSHKit.Host
 
-  def context(hosts) do
-    hosts =
-      hosts
-      |> List.wrap
-      |> Enum.map(&host/1)
-    %Context{hosts: hosts}
-  end
+  @doc """
+  Produces a SSHKit.Host struct holding the information
+  needed to connect to a (remote) host.
 
+  ## Example
+
+  There a many ways to create an SSHKit host:
+
+  ```
+  host = SSHKit.host(%{name: "me.fancy_domain.io", options: [port: 3000]})
+  ```
+
+  or
+
+  ```
+  host = SSHKit.host({"me.fancy_domain.io", [port: 3000]})
+  ```
+
+  or
+
+  ```
+  host = SSHKit.host({"me.fancy_domain.io", [port: 3000]})
+  ```
+
+  or
+
+  ```
+  host = SSHKit.host("10.0.0.1")
+  ```
+
+  or
+
+  ```
+  host = SSHKit.host("10.0.0.1", port: 3000)
+  ```
+
+  One or many of these hosts can then be used
+  to create an execution context in which commands
+  can be executed.
+
+  ```
+  host
+  |> SSHKit.context
+  |> SSHKit.run("echo \"That was fun\"")
+  ```
+  """
   def host(%{name: name, options: options}) do
     %Host{name: name, options: options}
   end
@@ -40,30 +78,191 @@ defmodule SSHKit do
     %Host{name: name, options: options}
   end
 
+  @doc """
+  See `host/1` for details and examples.
+  """
   def host(name, options \\ []) do
     %Host{name: name, options: options}
   end
 
+  @doc """
+  Takes one or more (remote) hosts and creates
+  an execution context in which remote commands can be run.
+
+  See `path/2`, `umask/2`, `user/2`, `group/2`, or `env/2`
+  for details on how to modify a context.
+
+  ## Example
+
+  Create an execution context for two hosts.
+  Commands issued on that context will be executed
+  on both hosts.
+
+  ```
+  hosts = ["10.0.0.1", "10.0.0.2"]
+  context = SSHKit.context(hosts)
+  ```
+  """
+  def context(hosts) do
+    hosts =
+      hosts
+      |> List.wrap
+      |> Enum.map(&host/1)
+    %Context{hosts: hosts}
+  end
+
+  @doc """
+  Changes the working directory commands are executed in
+  for the given context.
+  It returns the modified context for easy chaining.
+
+  ## Example
+
+  ```
+  # creates /var/www/my_app/my_file
+
+  "10.0.0.1"
+  |> SSHKit.context
+  |> SSHKit.path("/var/www/my_app")
+  |> SSHKit.run("touch my_file")
+  ```
+  """
   def path(context, path) do
     %Context{context | path: path}
   end
 
+  @doc """
+  Changes the umask affecting default file/directory
+  permission.
+  It returns the modified context for easy chaining.
+
+  ## Example
+
+  ```
+  # creates my_file, readable and writable only for the logged in user
+
+  "10.0.0.1"
+  |> SSHKit.context
+  |> SSHKit.umask("077")
+  |> SSHKit.run("touch my_file")
+  ```
+  """
   def umask(context, mask) do
     %Context{context | umask: mask}
   end
 
+  @doc """
+  Specifies the user under whose name commands are executed at.
+  That user might be different than the user with which
+  ssh connects to the remote host.
+  It returns the modified context for easy chaining.
+
+  ## Example
+
+  ```
+  context =
+    {"10.0.0.1", [port: 3000, user: "login_user", password: "secret"]}
+    |> SSHKit.context
+    |> SSHKit.user("deploy_user")
+  ```
+
+  All commands executed in the created `context` are
+  run under the user `deploy_user`, although we used
+  the `login_user` to log in to the remote host.
+  """
   def user(context, name) do
     %Context{context | user: name}
   end
 
+  @doc """
+  Specifies the unix group commands are executed with.
+  It returns the modified context for easy chaining.
+
+  ## Example
+
+  ```
+  context =
+    "10.0.0.1"
+    |> SSHKit.context
+    |> SSHKit.group("www")
+  ```
+  """
   def group(context, name) do
     %Context{context | group: name}
   end
 
+  @doc """
+  Defines new environment variables or overrides existing ones
+  for a given context.
+  It returns the modified context for easy chaining.
+
+  ## Examples
+
+  Setting `NODE_ENV=production`:
+  ```
+  context =
+    "10.0.0.1"
+    |> SSHKit.context
+    |> SSHKit.env(%{"NODE_ENV" => "production"})
+
+  # runs with NODE_ENV=production
+  SSHKit.run(context, "npm start")
+  ```
+
+  Modifying the `PATH`:
+  ```
+  context =
+    "10.0.0.1"
+    |> SSHKit.context
+    |> SSHKit.env(%{"PATH" => "$HOME/.rbenv/shims:$PATH"})
+
+  # Executes the rbenv-installed ruby to output "hello world"
+  SSHKit.run(context, "ruby -e \"puts 'hello world'\"")
+  ```
+  """
   def env(context, map) do
     %Context{context | env: map}
   end
 
+  @doc ~S"""
+  Executes a command within the given context.
+  Returns a list of tuples of the form `{:ok, output, return_code}`.
+  There is one tuple per connected host a command was executed at.
+
+  ## Parameters
+
+  * `return_code` is the number with which the executed command returns.
+    If things went well, that usually is `0`.
+
+  * `output` is a keyword list of the commands collected output.
+    It has the form:
+    ```
+    [
+      stdout: "output on standard out",
+      stderr: "output on standard error",
+      stdout: "some more normal output",
+    ]
+    ```
+
+  ## Example
+
+  Run a command and verify its output.
+
+  ```
+  {:ok, output, 0} =
+    "my.remote-host.tld"
+    |> SSHKit.context
+    |> SSHKit.run("echo \"Hello World!\"")
+
+  # join captured output fragments from stdout
+  stdout =
+    output
+    |> Keyword.get_values(:stdout)
+    |> Enum.join()
+
+  assert "Hello World!\n" == stdout
+  ```
+  """
   def run(context, command) do
     cmd = Context.build(context, command)
 


### PR DESCRIPTION
Added documentation for our main DSL

`mix inch --pedantic` now outputs:

```
# Properly documented, could be improved:
┃  B  →  SSHKit.host/1
┃  B  →  SSHKit.user/2
┃  B  →  SSHKit.SCP.download/4
┃  B  →  SSHKit.SSH.connect/2
┃  B  →  SSHKit.SCP.upload/4
┃  B  →  SSHKit.SSH.close/1
┃  B  →  SSHKit.SSH.run/3
┃  B  →  SSHKit.context/1
┃  B  →  SSHKit.group/2
┃  B  →  SSHKit.umask/2
┃  B  →  SSHKit.host/2
┃  B  →  SSHKit.path/2
┃  B  →  SSHKit.env/2
┃  B  →  SSHKit.run/2

You might want to look at these files:

┃ /lib/sshkit/host.ex
┃ /lib/sshkit/ssh.ex
┃ /lib/sshkit/scp.ex
┃ /lib/sshkit.ex

Grade distribution (undocumented, C, B, A):  ▁  ▁ █ ▃
```

---

* [x] Documented the change if necessary
