### PR TITLE
Fix code block in SSHKit.Context docstring

### DIFF
--- a/lib/sshkit/context.ex
+++ b/lib/sshkit/context.ex
@@ -16,10 +16,10 @@ defmodule SSHKit.Context do
 
   ## Example
 
-  ` ``
+  ```
   iex> %SSHKit.Context{path: "/var/www"} |> SSHKit.Context.build("ls")
   "cd /var/www && /usr/bin/env ls"
-  ` ``
+  ```
   """
   def build(context, command) do
     command


### PR DESCRIPTION
There was an error here @tessi… there should not be a space in between the three backticks. I only had those in there because they we're inside a GitHub comment code block and they would've broken the formatting otherwise. Sorry for that. I should've made that more obvious.