### PR TITLE
[#36] SSHKit.user errors because sudo is missing

### DIFF
--- a/lib/sshkit/utils.ex
+++ b/lib/sshkit/utils.ex
@@ -3,7 +3,7 @@ defmodule SSHKit.Utils do
 
   def shellescape(value), do: value
 
-  def shellquote(value), do: value
+  def shellquote(value), do: "'#{value}'" # TODO: Proper quoting
 
   def charlistify(value) when is_list(value) do
     Enum.map(value, &charlistify/1)

--- a/lib/sshkit/utils.ex
+++ b/lib/sshkit/utils.ex
@@ -3,7 +3,7 @@ defmodule SSHKit.Utils do
 
   def shellescape(value), do: value
 
-  def shellquote(value), do: "'#{value}'" # TODO: Proper quoting
+  def shellquote(value), do: "'#{value}'"
 
   def charlistify(value) when is_list(value) do
     Enum.map(value, &charlistify/1)

--- a/lib/sshkit/utils.ex
+++ b/lib/sshkit/utils.ex
@@ -10,7 +10,7 @@ defmodule SSHKit.Utils do
   end
   def charlistify(value) when is_tuple(value) do
     value
-    |> Tuple.to_list
+    |> Tuple.to_list()
     |> charlistify()
     |> List.to_tuple()
   end

--- a/test/sshkit/ssh_functional_test.exs
+++ b/test/sshkit/ssh_functional_test.exs
@@ -9,7 +9,7 @@ defmodule SSHKit.SSHFunctionalTest do
   test "opens a connection with username and password", %{hosts: [host]} do
     options = [port: host.port, user: host.user, password: host.password]
     {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-    {:ok, data, status} = SSH.run(conn, "whoami")
+    {:ok, data, status} = SSH.run(conn, "id -un")
 
     assert [stdout: "#{host.user}\n"] == data
     assert 0 = status

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -5,21 +5,15 @@ defmodule SSHKitFunctionalTest do
 
   use SSHKit.FunctionalCase, async: true
 
-  @defaults [silently_accept_hosts: true]
+  @defaults [silently_accept_hosts: true, timeout: 5000]
 
   def options(overrides) do
     Keyword.merge(@defaults, overrides)
   end
 
   def build_context(host) do
-    SSHKit.context({
-      host.ip,
-      options(port: host.port,
-              user: host.user,
-              password: host.password,
-              timeout: 5000
-             )
-    })
+    overrides = [port: host.port, user: host.user, password: host.password]
+    SSHKit.context({host.ip, Keyword.merge(@defaults, overrides)})
   end
 
   defp stdio(output, type) do
@@ -33,42 +27,39 @@ defmodule SSHKitFunctionalTest do
 
   @tag boot: 1
   test "connects", %{hosts: [host]} do
-    [{:ok, output, 0}] = SSHKit.run(build_context(host), "whoami")
-
+    [{:ok, output, 0}] = SSHKit.run(build_context(host), "id -un")
     name = String.trim(stdout(output))
     assert name == host.user
   end
 
   @tag boot: 1
-  test "run", %{hosts: [host]} do
+  test "runs commands", %{hosts: [host]} do
     context = build_context(host)
 
     [{:ok, output, status}] = SSHKit.run(context, "pwd")
     assert status == 0
-    output = stdout(output)
-    assert output == "/home/me\n"
+    assert stdout(output) == "/home/me\n"
 
     [{:ok, output, status}] = SSHKit.run(context, "ls non-existing")
     assert status == 1
-    output = stderr(output)
-    assert output =~ "ls: non-existing: No such file or directory"
+    assert stderr(output) =~ "ls: non-existing: No such file or directory"
 
     [{:ok, output, status}] = SSHKit.run(context, "does-not-exist")
     assert status == 127
-    output = stderr(output)
-    assert output =~ "'does-not-exist': No such file or directory"
+    assert stderr(output) =~ "'does-not-exist': No such file or directory"
   end
 
   @tag boot: 1
   test "env", %{hosts: [host]} do
     [{:ok, output, status}] =
       host
-      |> build_context
+      |> build_context()
       |> SSHKit.env(%{"PATH" => "$HOME/.rbenv/shims:$PATH", "NODE_ENV" => "production"})
       |> SSHKit.run("env")
 
-    assert status == 0
     output = stdout(output)
+
+    assert status == 0
     assert output =~ "NODE_ENV=production"
     assert output =~ ~r/PATH=.*\/\.rbenv\/shims:/
   end
@@ -77,14 +68,17 @@ defmodule SSHKitFunctionalTest do
   test "umask", %{hosts: [host]} do
     context =
       host
-      |> build_context
+      |> build_context()
       |> SSHKit.umask("077")
-    SSHKit.run(context, "mkdir my_dir")
-    SSHKit.run(context, "touch my_file")
+
+    [{:ok, _, 0}] = SSHKit.run(context, "mkdir my_dir")
+    [{:ok, _, 0}] = SSHKit.run(context, "touch my_file")
+
     [{:ok, output, status}] = SSHKit.run(context, "ls -la")
 
-    assert status == 0
     output = stdout(output)
+
+    assert status == 0
     assert output =~ ~r/drwx--S---\s+2\s+me\s+me\s+4096.+my_dir/
     assert output =~ ~r/-rw-------\s+1\s+me\s+me\s+0.+my_file/
   end
@@ -97,23 +91,25 @@ defmodule SSHKitFunctionalTest do
       |> SSHKit.path("/var/log")
 
     [{:ok, output, status}] = SSHKit.run(context, "pwd")
-    assert status == 0
     output = stdout(output)
+
+    assert status == 0
     assert output == "/var/log\n"
   end
 
-  @tag skip: true # it produces an error: "sudo not found" on stderr
   @tag boot: 1
   test "user", %{hosts: [host]} do
     adduser(host, "despicable_me")
+    add_user_to_group(host, host.user, "danger")
 
     context =
       host
-      |> build_context
+      |> build_context()
       |> SSHKit.user("despicable_me")
 
-    [{:ok, output, status}] = SSHKit.run(context, "whoami")
+    [{:ok, output, status}] = SSHKit.run(context, "id -un")
     output = stdout(output)
+
     assert output == "despicable_me\n"
     assert status == 0
   end

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -100,7 +100,7 @@ defmodule SSHKitFunctionalTest do
   @tag boot: 1
   test "user", %{hosts: [host]} do
     adduser(host, "despicable_me")
-    add_user_to_group(host, host.user, "danger")
+    add_user_to_group(host, host.user, "passwordless-sudoers")
 
     context =
       host

--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -20,8 +20,8 @@ RUN echo "%wheel ALL=(ALL) ALL" >> /etc/sudoers.d/wheel
 
 # Allow passwordless sudo for users in the "danger" group.
 
-RUN addgroup -S danger
-RUN echo "%danger ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/yolo
+RUN addgroup -S passwordless-sudoers
+RUN echo "%passwordless-sudoers ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/yolo
 
 # Run SSH daemon and expose the standard SSH port.
 

--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.5
 # Set up an Alpine Linux machine running an SSH server.
 # Autogenerate missing host keys.
 
-RUN apk add --no-cache openssh
+RUN apk add --no-cache openssh sudo
 RUN ssh-keygen -A
 
 # Create the skeleton directory, used for creating new users.
@@ -13,6 +13,15 @@ RUN chmod 700 /etc/skel/.ssh
 
 RUN touch /etc/skel/.ssh/authorized_keys
 RUN chmod 600 /etc/skel/.ssh/authorized_keys
+
+# Allow members of group "wheel" to execute any command.
+
+RUN echo "%wheel ALL=(ALL) ALL" >> /etc/sudoers.d/wheel
+
+# Allow passwordless sudo for users in the "danger" group.
+
+RUN addgroup -S danger
+RUN echo "%danger ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/yolo
 
 # Run SSH daemon and expose the standard SSH port.
 


### PR DESCRIPTION
Update the functional tests to allow the test/login user to run `sudo` in order to switch user/group.

TODOs:

- [x] Update "danger" group name to sth. better
- [x] ~Implement `SSHKit.Utils.shellquote/1`, and~ => https://github.com/bitcrowd/sshkit.ex/issues/54
- [x] ~`shellescape/1`~ => https://github.com/bitcrowd/sshkit.ex/issues/54