### PR TITLE
Contexts use UUID hashes for hosts, and pass to basic output formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.1...HEAD
 
 * Renamed response from remotely executed commands from 'normal' to 'stdout' [#34]
 * Renamed `SSHKit.pwd` to `SSHKit.path` [#33] Thanks @brienw for the idea
+* `SSH.run/3` accepts an optional `uuid` option and returns this `uuid` with the output
 
 ### New features:
 
 * Support basic SCP up-/downloads
 * Added documentation https://hexdocs.pm/sshkit/SSHKit.html
+* Basic output formatting (default is silent - no change)
 
 ### Fixes:
 

--- a/lib/sshkit/formatter.ex
+++ b/lib/sshkit/formatter.ex
@@ -1,0 +1,19 @@
+defmodule SSHKit.Formatter do
+  @moduledoc """
+  Output formatting functions for connections.
+
+  To create a new formatter, `use SSHKit.Formatter` and then define your own functions that are
+  listed as callbacks below.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour SSHKit.Formatter
+      alias SSHKit.Host
+    end
+  end
+
+  @callback puts_connect(%SSHKit.Host{}) :: nil
+  @callback puts_exec(String.t, String.t) :: nil
+  @callback puts_receive(String.t, :stdout | :stderr, String.t) :: nil
+end

--- a/lib/sshkit/formatters/pretty_formatter.ex
+++ b/lib/sshkit/formatters/pretty_formatter.ex
@@ -1,0 +1,43 @@
+defmodule SSHKit.Formatters.PrettyFormatter do
+  @moduledoc """
+  Formatter that uses `IO.ANSI` to colorize connection details.
+  """
+
+  use SSHKit.Formatter
+
+  def puts_connect(host = %Host{}) do
+    host.uuid
+    |> wrap_uuid()
+    |> List.flatten(["Connecting to ", IO.ANSI.bright, host.name, IO.ANSI.reset, "\n"])
+    |> IO.write()
+  end
+
+  def puts_exec(uuid, command) do
+    uuid
+    |> wrap_uuid()
+    |> List.flatten(["Running ", IO.ANSI.yellow, command, IO.ANSI.reset, "\n"])
+    |> IO.write()
+  end
+
+  def puts_receive(uuid, type, message) do
+    String.trim_trailing(message) <> "\n"
+    |> String.split("\n")
+    |> Enum.drop(-1)
+    |> Enum.map(&(wrap_uuid(uuid) ++ [color_std(type), &1, IO.ANSI.reset, "\n"]))
+    |> IO.write()
+  end
+
+  defp color_std(type) do
+    case type do
+      :stderr -> IO.ANSI.red
+            _ -> IO.ANSI.green
+    end
+  end
+
+  defp wrap_uuid(uuid) do
+    case uuid do
+      nil -> []
+      _ -> ["[", IO.ANSI.green, uuid, IO.ANSI.reset, "] "]
+    end
+  end
+end

--- a/lib/sshkit/formatters/silent_formatter.ex
+++ b/lib/sshkit/formatters/silent_formatter.ex
@@ -1,0 +1,13 @@
+defmodule SSHKit.Formatters.SilentFormatter do
+  @moduledoc """
+  Formatter that doesn't output anything (black hole).
+  """
+
+  use SSHKit.Formatter
+
+  def puts_connect(_host), do: nil
+
+  def puts_exec(_uuid, _command), do: nil
+
+  def puts_receive(_uuid, _type, _message), do: nil
+end

--- a/lib/sshkit/host.ex
+++ b/lib/sshkit/host.ex
@@ -11,5 +11,5 @@ defmodule SSHKit.Host do
   |> SSHKit.run("mkdir my_dir")
   ```
   """
-  defstruct [:name, :options]
+  defstruct [:name, :options, :uuid]
 end

--- a/test/sshkit/ssh_functional_test.exs
+++ b/test/sshkit/ssh_functional_test.exs
@@ -9,9 +9,19 @@ defmodule SSHKit.SSHFunctionalTest do
   test "opens a connection with username and password", %{hosts: [host]} do
     options = [port: host.port, user: host.user, password: host.password]
     {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-    {:ok, data, status} = SSH.run(conn, "whoami")
+    {:ok, data, status, uuid} = SSH.run(conn, "whoami")
 
     assert [stdout: "#{host.user}\n"] == data
     assert 0 = status
+    assert nil == uuid
+  end
+
+  @tag boot: 1
+  test "allows passing uuid as option", %{hosts: [host]} do
+    options = [port: host.port, user: host.user, password: host.password]
+    {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
+    {:ok, _data, _status, uuid} = SSH.run(conn, "whoami", uuid: "DEADBEEF")
+
+    assert "DEADBEEF" == uuid
   end
 end


### PR DESCRIPTION
When running a command on multiple machines, the output from that command is not currently associated with the remote connections. This PR attempts to change that by creating a UUID for each host on context creation, and passing that UUID around as needed.

We also have use for an output formatter but I believe this belongs more in SSHKit than individual apps. This PR includes two basic formatters, `SSHKit.Formatters.PrettyFormatter` and `SSHKit.Formatters.SilentFormatter` and defaults to the latter to remain as quiet as it is today. The formatter can be specified in calls to `SSHKit.run` and `SSHKit.SSH.run`. I didn't want to go too hog wild with implementing it elsewhere before seeking your feedback.

Thoughts?

Thanks!

---

* [x] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [x] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
