### PR TITLE
Add bang to helper functions

### DIFF
--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -98,9 +98,9 @@ defmodule SSHKitFunctionalTest do
 
   @tag boot: 1
   test "user", %{hosts: [host]} do
-    add_user_to_group(host, host.user, "passwordless-sudoers")
+    add_user_to_group!(host, host.user, "passwordless-sudoers")
 
-    adduser(host, "despicable_me")
+    adduser!(host, "despicable_me")
 
     context =
       host
@@ -115,11 +115,11 @@ defmodule SSHKitFunctionalTest do
 
   @tag boot: 1
   test "group", %{hosts: [host]} do
-    add_user_to_group(host, host.user, "passwordless-sudoers")
+    add_user_to_group!(host, host.user, "passwordless-sudoers")
 
-    adduser(host, "gru")
-    addgroup(host, "villains")
-    add_user_to_group(host, "gru", "villains")
+    adduser!(host, "gru")
+    addgroup!(host, "villains")
+    add_user_to_group!(host, "gru", "villains")
 
     context =
       host

--- a/test/support/functional_case.ex
+++ b/test/support/functional_case.ex
@@ -45,9 +45,9 @@ defmodule SSHKit.FunctionalCase do
   end
 
   def init(host) do
-    adduser(host, @user)
-    chpasswd(host, @user, @pass)
-    keygen(host, @user)
+    adduser!(host, @user)
+    chpasswd!(host, @user, @pass)
+    keygen!(host, @user)
 
     Map.merge(host, %{user: @user, password: @pass})
   end

--- a/test/support/functional_case_helpers.ex
+++ b/test/support/functional_case_helpers.ex
@@ -1,24 +1,24 @@
 defmodule SSHKit.FunctionalCaseHelpers do
   @moduledoc false
 
-  def adduser(_host = %{id: id}, username) do
+  def adduser!(_host = %{id: id}, username) do
     Docker.exec!([], id, "adduser", ["-D", username])
   end
 
-  def addgroup(_host = %{id: id}, groupname) do
+  def addgroup!(_host = %{id: id}, groupname) do
     Docker.exec!([], id, "addgroup", [groupname])
   end
 
-  def add_user_to_group(_host = %{id: id}, username, groupname) do
+  def add_user_to_group!(_host = %{id: id}, username, groupname) do
     Docker.exec!([], id, "addgroup", [username, groupname])
   end
 
-  def chpasswd(_host = %{id: id}, username, password) do
+  def chpasswd!(_host = %{id: id}, username, password) do
     command = "echo #{username}:#{password} | chpasswd 2>&1"
     Docker.exec!([], id, "sh", ["-c", command])
   end
 
-  def keygen(_host = %{id: id}, username) do
+  def keygen!(_host = %{id: id}, username) do
     Docker.exec!([], id, "sh", ["-c", "ssh-keygen -b 1024 -f /tmp/#{username} -N '' -C \"#{username}@$(hostname)\""])
     Docker.exec!([], id, "sh", ["-c", "cat /tmp/#{username}.pub > /home/#{username}/.ssh/authorized_keys"])
   end


### PR DESCRIPTION
Add a bang `!` to the functional helpers, to show they'll raise an exception if anything goes wrong (they're using the Docker helpers underneath).

This is based on #55 & #56. If these are okay/merged, then only the changes in c1d9c7a are really relevant to this PR.