### PR TITLE
Add shared options support to SSHKit.context

### DIFF
--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -124,13 +124,22 @@ defmodule SSHKit do
   hosts = [{"10.0.0.3", port: 2223}, %{name: "10.0.0.4", options: [port: 2224]}]
   context = SSHKit.context(hosts)
   ```
+
+  Any shared options can be specified in the second argument.
+  Here we add a user and port for all hosts.
+
+  ```
+  hosts = ["10.0.0.1", "10.0.0.2"]
+  options = [user: "admin", port: "2222"]
+  context = SSHKit.context(hosts, options)
+  ```
   """
 
-  def context(hosts, options \\ []) do
+  def context(hosts, shared_options \\ []) do
     hosts =
       hosts
       |> List.wrap()
-      |> Enum.map(&host/1)
+      |> build_hosts(shared_options)
     %Context{hosts: hosts}
   end
 
@@ -323,4 +332,9 @@ defmodule SSHKit do
   #   local = Map.get(options, :as, Path.basename(path))
   #   SCP.download(conn, remote, local, options)
   # end
+
+  defp build_hosts(hosts, shared_options) do
+    build_host = &host(&1, shared_options)
+    Enum.map(hosts, build_host)
+  end
 end

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -87,8 +87,17 @@ defmodule SSHKit do
 
   See `host/1` for additional ways of specifying host details.
   """
-  def host(name, options \\ []) do
+  def host(host, options \\ [])
+  def host(name, options) when is_binary(name) do
     %Host{name: name, options: options}
+  end
+
+  def host(%{name: name, options: options}, shared_options) do
+    %Host{name: name, options: Keyword.merge(shared_options, options)}
+  end
+
+  def host({name, options}, shared_options) do
+    %Host{name: name, options: Keyword.merge(shared_options, options)}
   end
 
   @doc """
@@ -116,7 +125,8 @@ defmodule SSHKit do
   context = SSHKit.context(hosts)
   ```
   """
-  def context(hosts) do
+
+  def context(hosts, options \\ []) do
     hosts =
       hosts
       |> List.wrap()

--- a/test/sshkit/sshkit_test.exs
+++ b/test/sshkit/sshkit_test.exs
@@ -1,0 +1,83 @@
+defmodule SSHKitTest do
+  use ExUnit.Case, async: true
+
+  alias SSHKit.Context
+  alias SSHKit.Host
+
+  @context_simple %Context{hosts: [
+                    %Host{name: "10.0.0.1", options: []},
+                    %Host{name: "10.0.0.2", options: []},
+                    %Host{name: "10.0.0.3", options: []}
+                  ]}
+  @context_options %Context{hosts: [
+                    %Host{name: "10.0.0.1", options: [user: "user"]},
+                    %Host{name: "10.0.0.2", options: [user: "user"]},
+                    %Host{name: "10.0.0.3", options: [user: "user"]}
+                  ]}
+  @context_merged_options %Context{hosts: [
+                    %Host{name: "10.0.0.1", options: [user: "user", password: "123"]},
+                    %Host{name: "10.0.0.2", options: [user: "user"]},
+                    %Host{name: "10.0.0.3", options: [user: "user"]}
+                  ]}
+  @options [user: "user"]
+
+  describe "context/2" do
+    test "creates with list of binaries" do
+      hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+      context = SSHKit.context(hosts)
+
+      assert context == @context_simple
+    end
+
+    test "creates with list of Maps" do
+      hosts = [
+        %{name: "10.0.0.1", options: []},
+        %{name: "10.0.0.2", options: []},
+        %{name: "10.0.0.3", options: []}
+      ]
+      context = SSHKit.context(hosts)
+
+      assert context == @context_simple
+    end
+
+    test "creates with mixed list" do
+      hosts = [
+        "10.0.0.1",
+        %{name: "10.0.0.2", options: []},
+        %Host{name: "10.0.0.3", options: []}
+      ]
+      context = SSHKit.context(hosts)
+
+      assert context == @context_simple
+    end
+
+    test "includes shared options" do
+      hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+      context = SSHKit.context(hosts, @options)
+      assert context == @context_options
+    end
+
+    test "merges shared options" do
+      hosts = [
+        %{name: "10.0.0.1", options: [password: "123"]},
+        "10.0.0.2",
+        "10.0.0.3"
+      ]
+      context = SSHKit.context(hosts, @options)
+      assert context == @context_merged_options
+    end
+
+    test "does not override host options with shared options" do
+      expected_context = %Context{hosts: [
+          %Host{name: "10.0.0.1", options: [user: "host_user"]},
+          %Host{name: "10.0.0.2", options: [user: "user"]}
+        ]}
+      hosts = [
+        %{name: "10.0.0.1", options: [user: "host_user"]},
+        "10.0.0.2"
+      ]
+      context = SSHKit.context(hosts, @options)
+      assert context == expected_context
+    end
+  end
+end


### PR DESCRIPTION
Proposed change for #60 

Adds shared option support during `Context` creation. This will retain any host options already specified, and additionally merge in all shared options to each host in the list. In the case that host option and shared option contain the same key, the host-specific option is retained.

---

* [X] Documented the change if necessary
* [X] Tested this PRs change (with unit and/or functional tests)
* [X] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
