### PR TITLE
Use `with` over nested `case` calls

### DIFF
--- a/lib/sshkit/ssh.ex
+++ b/lib/sshkit/ssh.ex
@@ -82,19 +82,17 @@ defmodule SSHKit.SSH do
     acc = Keyword.get(options, :acc, {:cont, {[], nil}})
     fun = Keyword.get(options, :fun, &capture/2)
 
-    case Channel.open(connection, timeout: timeout) do
-      {:ok, channel} ->
-        case Channel.exec(channel, command, timeout) do
-          :success ->
-            channel
-            |> Channel.loop(timeout, acc, fun)
-            |> elem(1)
-          :failure ->
-            {:error, :failure}
-          err ->
-            err
-        end
-      err -> err
+    with {:ok, channel} <- Channel.open(connection, timeout: timeout) do
+      case Channel.exec(channel, command, timeout) do
+        :success ->
+          channel
+          |> Channel.loop(timeout, acc, fun)
+          |> elem(1)
+        :failure ->
+          {:error, :failure}
+        err ->
+          err
+      end
     end
   end
 


### PR DESCRIPTION
This is just a tiny refactoring which makes `SSHKit.SSH.run/3` more readable by using the [`with`](https://elixir-lang.org/getting-started/mix-otp/docs-tests-and-with.html#with) construct introduced in Elixir 1.2.