### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       services: docker
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 script:
   - mix credo --strict
   - mix test


### PR DESCRIPTION
The `docker-engine` package previously installed to run Docker
containers for our functional tests on Travis is no longer available.

Instead, use the new `docker-ce` package.

---

For the error message, see [this build on Travis CI](https://travis-ci.org/bitcrowd/sshkit.ex/jobs/246111827#L620-L629).