### PR TITLE
[#72] Allow SSH.connect to receive a lambda where the connection is only open within the lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.2...HEAD
 
 ### New features:
 
-* Put new features here
+* Added support for passing an anonymous function to `SSH.connect` [#72]
 
 ### Fixes:
 

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -1,0 +1,48 @@
+defmodule SSHKit.SSHTest do
+  use ExUnit.Case, async: true
+
+  import SSHKit.SSH
+
+  defmodule SSHSandboxSuccess do
+    def connect(_, _, _, _), do: {:ok, :sandbox}
+    def close(_) do
+      send self(), :closed_sandbox_connection
+      :ok
+    end
+  end
+
+  defmodule SSHSandboxError do
+    def connect(_, _, _, _), do: {:error, :sandbox}
+  end
+
+  describe "connect/3" do
+    @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
+    test "execute function on open connection" do
+      host = "foo"
+      func = fn(conn) ->
+        assert conn.ssh_modules == Keyword.get(@options, :ssh_modules)
+        42
+      end
+
+      assert connect(host, @options, func) == {:ok, 42}
+      assert_received :closed_sandbox_connection
+    end
+
+    test "close connection although function errored" do
+      host = "foo"
+      func = fn(_conn) -> raise("error") end
+
+      assert_raise RuntimeError, "error", fn -> connect(host, @options, func) end
+      assert_received :closed_sandbox_connection
+    end
+
+    @options [ssh_modules: %{ssh: SSHSandboxError, ssh_connection: :ssh_connection}]
+    test "error during connect" do
+      host = "foo"
+      func = fn(_conn) -> flunk "should never be called" end
+
+      assert connect(host, @options, func) == {:error, :sandbox}
+      refute_received :closed_sandbox_connection
+    end
+  end
+end


### PR DESCRIPTION
This extends SSHKit.SSH with connect/3 which accepts a function that is
called with the connection. The connection is automatically closed after
the function returned, no matter if it errored or not.

Also: this introduces a new option - "ssh_modules" for
SSHKit.SSH.connect that allows to use own implementations for the
underlying Erlang modules. This can be used for unit testing SSHKit.

This is supposed to close #72 

---

* [x] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [x] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
