### PR TITLE
[#74] Add unit tests for the SSH module

### DIFF
--- a/lib/sshkit/ssh.ex
+++ b/lib/sshkit/ssh.ex
@@ -102,7 +102,7 @@ defmodule SSHKit.SSH do
 
   ## Options
 
-  * `:timeout` - maximum wait time between messages, defautls to `:infinity`
+  * `:timeout` - maximum wait time between messages, defaults to `:infinity`
   * `:fun` - handler function passed to `SSHKit.SSH.Channel.loop/4`
   * `:acc` - initial accumulator value used in the loop
 

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -31,8 +31,9 @@ defmodule SSHKit.SSH.Channel do
     timeout = Keyword.get(options, :timeout, :infinity)
     ini_window_size = Keyword.get(options, :initial_window_size, 128 * 1024)
     max_packet_size = Keyword.get(options, :max_packet_size, 32 * 1024)
+    ssh_connection  = erlang_module(connection, :ssh_connection)
 
-    case :ssh_connection.session_channel(connection.ref, ini_window_size, max_packet_size, timeout) do
+    case ssh_connection.session_channel(connection.ref, ini_window_size, max_packet_size, timeout) do
       {:ok, id} -> {:ok, %Channel{connection: connection, type: :session, id: id}}
       err -> err
     end
@@ -66,7 +67,12 @@ defmodule SSHKit.SSH.Channel do
     exec(channel, to_charlist(command), timeout)
   end
   def exec(channel, command, timeout) do
-    :ssh_connection.exec(channel.connection.ref, channel.id, command, timeout)
+    ssh_connection = erlang_module(channel.connection, :ssh_connection)
+    ssh_connection.exec(channel.connection.ref, channel.id, command, timeout)
+  end
+
+  defp erlang_module(conn, name) do
+    Map.fetch!(conn.ssh_modules, name)
   end
 
   @doc """

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -85,4 +85,20 @@ defmodule SSHKit.SSHTest do
       refute_received :closed_sandbox_connection
     end
   end
+
+  describe "close/1" do
+    @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
+    test "call close on the connection" do
+      conn = %SSHKit.SSH.Connection{
+        host:        'test',
+        options:     [user_interaction: false],
+        port:        22,
+        ref:         :sandbox,
+        ssh_modules: Keyword.get(@options, :ssh_modules)
+      }
+
+      assert close(conn) == :ok
+      assert_received :closed_sandbox_connection
+    end
+  end
 end

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -13,35 +13,75 @@ defmodule SSHKit.SSHTest do
 
   defmodule SSHSandboxError do
     def connect(_, _, _, _), do: {:error, :sandbox}
+
+    def close(_) do
+      send self(), :closed_sandbox_connection
+      :ok
+    end
+  end
+
+  setup_all do
+    {:ok, host: "foo.io"}
+  end
+
+  describe "connect/2" do
+    @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
+    test "open sandbox connection with given options and keep it open", state do
+      user = "test"
+      options = @options ++ [user: user]
+      conn = %SSHKit.SSH.Connection{
+        host:        String.to_charlist(state[:host]),
+        options:     [user_interaction: false, user: String.to_charlist(user)],
+        port:        22,
+        ref:         :sandbox,
+        ssh_modules: Keyword.get(options, :ssh_modules)
+      }
+
+      assert connect(state[:host], options) == {:ok, conn}
+      refute_received :closed_sandbox_connection
+    end
+
+    @options [ssh_modules: %{ssh: SSHSandboxError, ssh_connection: :ssh_connection}]
+    test "return error and do not attempt to close if connection cannot be opened", state do
+      assert connect(state[:host], @options) == {:error, :sandbox}
+      refute_received :closed_sandbox_connection
+    end
+
+    test "return error and do not attempt to close if no host given" do
+      assert connect(nil, @options) == {:error, "No host given."}
+      refute_received :closed_sandbox_connection
+    end
+
+    test "error if options not provided as List", state do
+      options = %{user: "me", password: "secret"}
+      assert_raise FunctionClauseError, fn -> connect(state[:host], options) end
+    end
   end
 
   describe "connect/3" do
     @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
-    test "execute function on open connection" do
-      host = "foo"
+    test "execute function on open connection", state do
       func = fn(conn) ->
         assert conn.ssh_modules == Keyword.get(@options, :ssh_modules)
         42
       end
 
-      assert connect(host, @options, func) == {:ok, 42}
+      assert connect(state[:host], @options, func) == {:ok, 42}
       assert_received :closed_sandbox_connection
     end
 
-    test "close connection although function errored" do
-      host = "foo"
+    test "close connection although function errored", state do
       func = fn(_conn) -> raise("error") end
 
-      assert_raise RuntimeError, "error", fn -> connect(host, @options, func) end
+      assert_raise RuntimeError, "error", fn -> connect(state[:host], @options, func) end
       assert_received :closed_sandbox_connection
     end
 
     @options [ssh_modules: %{ssh: SSHSandboxError, ssh_connection: :ssh_connection}]
-    test "error during connect" do
-      host = "foo"
+    test "error during connect", state do
       func = fn(_conn) -> flunk "should never be called" end
 
-      assert connect(host, @options, func) == {:error, :sandbox}
+      assert connect(state[:host], @options, func) == {:error, :sandbox}
       refute_received :closed_sandbox_connection
     end
   end

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -20,6 +20,24 @@ defmodule SSHKit.SSHTest do
     end
   end
 
+  defmodule SSHSandboxConnectionSuccess do
+    def session_channel(:sandbox, _, _, _), do: {:ok, 0}
+
+    def exec(_, _, _, _) do
+      send self(), :exec_sandbox_connection
+      {:ok, :result}
+    end
+  end
+
+  defmodule SSHSandboxConnectionError do
+    def session_channel(:sandbox, _, _, _), do: {:ok, 0}
+
+    def exec(_, _, _, _) do
+      send self(), :exec_sandbox_connection
+      :failure
+    end
+  end
+
   setup_all do
     {:ok, host: "foo.io"}
   end
@@ -99,6 +117,46 @@ defmodule SSHKit.SSHTest do
 
       assert close(conn) == :ok
       assert_received :closed_sandbox_connection
+    end
+  end
+
+  describe "run/3" do
+    @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
+    test "error if Channel cannot be opened" do
+      conn = %SSHKit.SSH.Connection{
+        host:        'test',
+        options:     [user_interaction: false],
+        port:        22,
+        ref:         :sandbox,
+        ssh_modules: Keyword.get(@options, :ssh_modules)
+      }
+      assert run(conn, "uptime") == {:error, :closed}
+    end
+
+    @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: SSHSandboxConnectionSuccess}]
+    test "sucessfully execute command on connection and return result" do
+      conn = %SSHKit.SSH.Connection{
+        host:        'test',
+        options:     [user_interaction: false],
+        port:        22,
+        ref:         :sandbox,
+        ssh_modules: Keyword.get(@options, :ssh_modules)
+      }
+      assert run(conn, "uptime") == {:ok, :result}
+      assert_received :exec_sandbox_connection
+    end
+
+    @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: SSHSandboxConnectionError}]
+    test "error when execution of command returns failure" do
+      conn = %SSHKit.SSH.Connection{
+        host:        'test',
+        options:     [user_interaction: false],
+        port:        22,
+        ref:         :sandbox,
+        ssh_modules: Keyword.get(@options, :ssh_modules)
+      }
+      assert run(conn, "uptime") == {:error, :failure}
+      assert_received :exec_sandbox_connection
     end
   end
 end

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -38,30 +38,30 @@ defmodule SSHKit.SSHTest do
     end
   end
 
-  setup_all do
-    {:ok, host: "foo.io"}
-  end
+  @host "foo.io"
+  @user "me"
 
   describe "connect/2" do
     @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
-    test "open sandbox connection with given options and keep it open", state do
-      user = "test"
-      options = @options ++ [user: user]
+    test "open sandbox connection with given options and keep it open" do
+      host = String.to_charlist(@host)
+      user = String.to_charlist(@user)
+      options = @options ++ [user: @user]
       conn = %SSHKit.SSH.Connection{
-        host:        String.to_charlist(state[:host]),
-        options:     [user_interaction: false, user: String.to_charlist(user)],
+        host:        host,
+        options:     [user_interaction: false, user: user],
         port:        22,
         ref:         :sandbox,
         ssh_modules: Keyword.get(options, :ssh_modules)
       }
 
-      assert connect(state[:host], options) == {:ok, conn}
+      assert connect(@host, options) == {:ok, conn}
       refute_received :closed_sandbox_connection
     end
 
     @options [ssh_modules: %{ssh: SSHSandboxError, ssh_connection: :ssh_connection}]
-    test "return error and do not attempt to close if connection cannot be opened", state do
-      assert connect(state[:host], @options) == {:error, :sandbox}
+    test "return error and do not attempt to close if connection cannot be opened" do
+      assert connect(@host, @options) == {:error, :sandbox}
       refute_received :closed_sandbox_connection
     end
 
@@ -70,36 +70,36 @@ defmodule SSHKit.SSHTest do
       refute_received :closed_sandbox_connection
     end
 
-    test "error if options not provided as List", state do
+    test "error if options not provided as List" do
       options = %{user: "me", password: "secret"}
-      assert_raise FunctionClauseError, fn -> connect(state[:host], options) end
+      assert_raise FunctionClauseError, fn -> connect(@host, options) end
     end
   end
 
   describe "connect/3" do
     @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: :ssh_connection}]
-    test "execute function on open connection", state do
+    test "execute function on open connection" do
       func = fn(conn) ->
         assert conn.ssh_modules == Keyword.get(@options, :ssh_modules)
         42
       end
 
-      assert connect(state[:host], @options, func) == {:ok, 42}
+      assert connect(@host, @options, func) == {:ok, 42}
       assert_received :closed_sandbox_connection
     end
 
-    test "close connection although function errored", state do
+    test "close connection although function errored" do
       func = fn(_conn) -> raise("error") end
 
-      assert_raise RuntimeError, "error", fn -> connect(state[:host], @options, func) end
+      assert_raise RuntimeError, "error", fn -> connect(@host, @options, func) end
       assert_received :closed_sandbox_connection
     end
 
     @options [ssh_modules: %{ssh: SSHSandboxError, ssh_connection: :ssh_connection}]
-    test "error during connect", state do
+    test "error during connect" do
       func = fn(_conn) -> flunk "should never be called" end
 
-      assert connect(state[:host], @options, func) == {:error, :sandbox}
+      assert connect(@host, @options, func) == {:error, :sandbox}
       refute_received :closed_sandbox_connection
     end
   end


### PR DESCRIPTION
This adds some unit test for the public api of `SSHKit.SSH` as specified in #74.

I for now only tested certain limited scenarios of `run/3`, since anything else would require a deeper dive into the internals of `SSH.Channel` *(or an infinite loop 🙈 )*.
I would prefer to first unit test both, `Channel` and `Connection` before getting back to it, as I for now don't have the domain knowledge of both.

As unit tests are blazing fast in Elixir *(plus can be run in parallel)*, I think it makes sense to have all modules unittested anyways.

---

* [x] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [x] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
