### PR TITLE
[#76] Add functional tests for SSH.connect with lambda functions

### DIFF
--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -9,42 +9,39 @@ defmodule SSHKit.SCPFunctionalTest do
   describe "upload/4" do
     @tag boot: 1
     test "sends a file", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures/local_workspace/local_file.txt"
       remote = "file.txt"
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.upload(conn, local, remote)
-      assert verify_transfer(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.upload(conn, local, remote)
+        assert verify_transfer(conn, local, remote)
+      end
     end
 
     @tag boot: 1
     test "recursive: true", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures/local_workspace"
       remote = "/home/#{host.user}/destination"
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.upload(conn, local, remote, recursive: true)
-      assert verify_transfer(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.upload(conn, local, remote, recursive: true)
+        assert verify_transfer(conn, local, remote)
+      end
     end
 
     @tag boot: 1
     test "preserve: true", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures/local_workspace/local_file.txt"
       remote = "file.txt"
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.upload(conn, local, remote, preserve: true)
-      assert verify_mode(conn, local, remote)
-      assert verify_mtime(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.upload(conn, local, remote, preserve: true)
+        assert verify_mode(conn, local, remote)
+        assert verify_mtime(conn, local, remote)
+      end
     end
 
     @tag boot: 1
@@ -53,74 +50,69 @@ defmodule SSHKit.SCPFunctionalTest do
       local = "test/fixtures/local_workspace/"
       remote = "/home/#{host.user}/destination"
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.upload(conn, local, remote, recursive: true, preserve: true)
-      assert verify_mode(conn, local, remote)
-      assert verify_mtime(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.upload(conn, local, remote, recursive: true, preserve: true)
+        assert verify_mode(conn, local, remote)
+        assert verify_mtime(conn, local, remote)
+      end
     end
   end
 
   describe "download/4" do
     @tag boot: 1
     test "gets a file", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures/file.txt"
       local = create_random_path()
       on_exit fn -> File.rm(local) end
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.download(conn, remote, local)
-      assert verify_transfer(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.download(conn, remote, local)
+        assert verify_transfer(conn, local, remote)
+      end
     end
 
     @tag boot: 1
     test "recursive: true", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures"
       local = create_random_path()
       on_exit fn -> File.rm_rf(local) end
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.download(conn, remote, local, recursive: true)
-      assert verify_transfer(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.download(conn, remote, local, recursive: true)
+        assert verify_transfer(conn, local, remote)
+      end
     end
 
     @tag boot: 1
     test "preserve: true", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures/file.txt"
       local = create_random_path()
       on_exit fn -> File.rm(local) end
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.download(conn, remote, local, preserve: true)
-      assert verify_mode(conn, local, remote)
-      assert verify_atime(conn, local, remote)
-      assert verify_mtime(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.download(conn, remote, local, preserve: true)
+        assert verify_mode(conn, local, remote)
+        assert verify_atime(conn, local, remote)
+        assert verify_mtime(conn, local, remote)
+      end
     end
 
     @tag boot: 1
     test "recursive: true, preserve: true", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
+      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures"
       local = create_random_path()
       on_exit fn -> File.rm_rf(local) end
 
-      {:ok, conn} = SSH.connect(host.ip, Keyword.merge(@defaults, options))
-
-      assert :ok = SCP.download(conn, remote, local, recursive: true, preserve: true)
-      assert verify_mode(conn, local, remote)
-      assert verify_atime(conn, local, remote)
-      assert verify_mtime(conn, local, remote)
-      :ok = SSH.close(conn)
+      SSH.connect host.ip, options, fn(conn) ->
+        assert :ok = SCP.download(conn, remote, local, recursive: true, preserve: true)
+        assert verify_mode(conn, local, remote)
+        assert verify_atime(conn, local, remote)
+        assert verify_mtime(conn, local, remote)
+      end
     end
   end
 
@@ -165,5 +157,4 @@ defmodule SSHKit.SCPFunctionalTest do
   defp create_random_path do
     "/tmp/test_#{16 |> :crypto.strong_rand_bytes |> Base.url_encode64 |> binary_part(0, 16)}"
   end
-
 end

--- a/test/sshkit/ssh_functional_test.exs
+++ b/test/sshkit/ssh_functional_test.exs
@@ -15,6 +15,15 @@ defmodule SSHKit.SSHFunctionalTest do
     assert 0 = status
   end
 
+  @tag boot: 1
+  test "opens a connection and runs an SSH command as a lambda function", %{hosts: [host]} do
+    options = [port: host.port, user: host.user, password: host.password]
+    func    = fn(conn) -> SSH.run(conn, "id -un") end
+    result  = {:ok, [stdout: "me\n"], 0}
+
+    assert SSH.connect(host.ip, options, func) == {:ok, result}
+  end
+
   test "returns error with nil host" do
     assert {:error, _} = SSH.connect(nil)
   end

--- a/test/sshkit/ssh_functional_test.exs
+++ b/test/sshkit/ssh_functional_test.exs
@@ -17,7 +17,7 @@ defmodule SSHKit.SSHFunctionalTest do
 
   @tag boot: 1
   test "opens a connection and runs an SSH command as a lambda function", %{hosts: [host]} do
-    options = [port: host.port, user: host.user, password: host.password]
+    options = @defaults ++ [port: host.port, user: host.user, password: host.password]
     func    = fn(conn) -> SSH.run(conn, "id -un") end
     result  = {:ok, [stdout: "me\n"], 0}
 


### PR DESCRIPTION
This adds another small functional test for SSH.connect. It does the
same as the existing one but utilizes a lambda function for this.

---

* [x] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [x] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
