### PR TITLE
[#68] Allow dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.2...HEAD
 ### New features:
 
 * Added support for passing an anonymous function to `SSH.connect` [#72]
+* Add support for passing a `dry_run` flag to `SSHKit.SSH.connect` [#79]
 
 ### Fixes:
 

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -31,7 +31,7 @@ defmodule SSHKit.SSH.Channel do
     timeout = Keyword.get(options, :timeout, :infinity)
     ini_window_size = Keyword.get(options, :initial_window_size, 128 * 1024)
     max_packet_size = Keyword.get(options, :max_packet_size, 32 * 1024)
-    ssh_connection  = erlang_module(connection, :ssh_connection)
+    ssh_connection  = ssh_connection_module(connection)
 
     case ssh_connection.session_channel(connection.ref, ini_window_size, max_packet_size, timeout) do
       {:ok, id} -> {:ok, %Channel{connection: connection, type: :session, id: id}}
@@ -47,7 +47,8 @@ defmodule SSHKit.SSH.Channel do
   For more details, see [`:ssh_connection.close/2`](http://erlang.org/doc/man/ssh_connection.html#close-2).
   """
   def close(channel) do
-    :ssh_connection.close(channel.connection.ref, channel.id)
+    ssh_connection = ssh_connection_module(channel.connection)
+    ssh_connection.close(channel.connection.ref, channel.id)
   end
 
   @doc """
@@ -67,12 +68,8 @@ defmodule SSHKit.SSH.Channel do
     exec(channel, to_charlist(command), timeout)
   end
   def exec(channel, command, timeout) do
-    ssh_connection = erlang_module(channel.connection, :ssh_connection)
+    ssh_connection = ssh_connection_module(channel.connection)
     ssh_connection.exec(channel.connection.ref, channel.id, command, timeout)
-  end
-
-  defp erlang_module(conn, name) do
-    Map.fetch!(conn.ssh_modules, name)
   end
 
   @doc """
@@ -87,7 +84,8 @@ defmodule SSHKit.SSH.Channel do
   def send(channel, type \\ 0, data, timeout \\ :infinity)
 
   def send(channel, type, data, timeout) when is_binary(data) or is_list(data) do
-    :ssh_connection.send(channel.connection.ref, channel.id, type, data, timeout)
+    ssh_connection = ssh_connection_module(channel.connection)
+    ssh_connection.send(channel.connection.ref, channel.id, type, data, timeout)
   end
 
   def send(channel, type, data, timeout) do
@@ -102,7 +100,8 @@ defmodule SSHKit.SSH.Channel do
   For more details, see [`:ssh_connection.send_eof/2`](http://erlang.org/doc/man/ssh_connection.html#send_eof-2).
   """
   def eof(channel) do
-    :ssh_connection.send_eof(channel.connection.ref, channel.id)
+    ssh_connection = ssh_connection_module(channel.connection)
+    ssh_connection.send_eof(channel.connection.ref, channel.id)
   end
 
   @doc """
@@ -162,7 +161,8 @@ defmodule SSHKit.SSH.Channel do
   For more details, see [`:ssh_connection.adjust_window/3`](http://erlang.org/doc/man/ssh_connection.html#adjust_window-3).
   """
   def adjust(channel, size) when is_integer(size) do
-    :ssh_connection.adjust_window(channel.connection.ref, channel.id, size)
+    ssh_connection = ssh_connection_module(channel.connection)
+    ssh_connection.adjust_window(channel.connection.ref, channel.id, size)
   end
 
   @doc """
@@ -266,4 +266,8 @@ defmodule SSHKit.SSH.Channel do
   end
 
   defp ljust(_, _), do: :ok
+
+  defp ssh_connection_module(conn) do
+    Map.fetch!(conn.ssh_modules, :ssh_connection)
+  end
 end

--- a/lib/sshkit/ssh/connection.ex
+++ b/lib/sshkit/ssh/connection.ex
@@ -21,14 +21,16 @@ defmodule SSHKit.SSH.Connection do
   @doc """
   Opens a connection to an SSH server.
 
-  A timeout in ms can be provided through the `:timeout` option.
-  The default value is `:infinity`.
+  The following options are allowed:
 
-  A few more, common options are `:port`, `:user` and `:password`.
-  Port defaults to `22`, user to `$LOGNAME` or `$USER` on UNIX,
-  `$USERNAME` on Windows.
-
-  The `:user_interaction` option is set to false by default.
+  * `:timeout`: A timeout in ms after which a command is aborted. Defaults to `:infinity`.
+  * `:port`: The remote-port to connect to. Defaults to 22.
+  * `:user`: The username with which to connect.
+             Defaults to `$LOGNAME`, or `$USER` on UNIX, or `$USERNAME` on windows.
+  * `:password`: The password to login with
+  * `:dry_run`: If set to `true` no actual connection to the remote is established.
+                Instead all commands a logged. Defaults to `false`.
+  * `:user_interaction`: Defaults to `false`.
 
   For a complete list of options and their default values, see:
   [`:ssh.connect/4`](http://erlang.org/doc/man/ssh.html#connect-4).

--- a/lib/sshkit/ssh/connection.ex
+++ b/lib/sshkit/ssh/connection.ex
@@ -10,7 +10,8 @@ defmodule SSHKit.SSH.Connection do
   * `ref` - the underlying `:ssh` connection ref
   """
 
-  alias SSHKit.SSH.{Connection, DryRun}
+  alias SSHKit.SSH.Connection
+  alias SSHKit.SSH.DryRun
   alias SSHKit.Utils
 
   defstruct [:host, :port, :options, :ref, :ssh_modules]
@@ -45,7 +46,7 @@ defmodule SSHKit.SSH.Connection do
     open(to_charlist(host), options)
   end
   def open(host, options) do
-    { ssh_options, sshkit_options } = fetch_options(options)
+    {ssh_options, sshkit_options} = fetch_options(options)
 
     ssh = ssh_module(sshkit_options)
     case ssh.connect(host, sshkit_options.port, ssh_options, sshkit_options.timeout) do
@@ -85,7 +86,7 @@ defmodule SSHKit.SSH.Connection do
       |> Keyword.drop([:port, :timeout, :ssh_modules, :dry_run])
       |> Utils.charlistify()
 
-    { erlang_ssh_options, sshkit_options }
+    {erlang_ssh_options, sshkit_options}
   end
 
   defp ssh_module(conn) do

--- a/lib/sshkit/ssh/dry_run/ssh.ex
+++ b/lib/sshkit/ssh/dry_run/ssh.ex
@@ -1,0 +1,17 @@
+defmodule SSHKit.SSH.DryRun.SSH do
+  @moduledoc false
+
+  require Logger
+
+  def connect(host, port, _options, _timeout) do
+    Logger.info("Connect: #{host}:#{port}")
+
+    {:ok, "#{host}:#{port}"}
+  end
+
+  def close(ref) do
+    Logger.info("Disconnected #{ref}")
+
+    :ok
+  end
+end

--- a/lib/sshkit/ssh/dry_run/ssh.ex
+++ b/lib/sshkit/ssh/dry_run/ssh.ex
@@ -3,14 +3,19 @@ defmodule SSHKit.SSH.DryRun.SSH do
 
   require Logger
 
-  def connect(host, port, _options, _timeout) do
-    Logger.info("Connect: #{host}:#{port}")
+  def connect(host, port, options, _timeout) do
+    login_identifier = if options[:user] do
+      "#{options[:user]}@#{host}:#{port}"
+    else
+      "#{host}:#{port}"
+    end
 
-    {:ok, "#{host}:#{port}"}
+    Logger.info("Connect: #{login_identifier}")
+    {:ok, login_identifier}
   end
 
   def close(ref) do
-    Logger.info("Disconnected #{ref}")
+    Logger.info("Disconnect: #{ref}")
 
     :ok
   end

--- a/lib/sshkit/ssh/dry_run/ssh_connection.ex
+++ b/lib/sshkit/ssh/dry_run/ssh_connection.ex
@@ -1,0 +1,34 @@
+defmodule SSHKit.SSH.DryRun.SSHConnection do
+  @moduledoc false
+
+  require Logger
+
+  @ssh_channel_id :dry_run_channel
+  def session_channel(_ref, _ini_window_size, _max_packet_size, _timeout) do
+    {:ok, @ssh_channel_id}
+  end
+
+  def close(_ref, _id) do
+    :ok
+  end
+
+  def exec(ref, id, command, _timeout) do
+    Logger.info("Command: #{command}")
+
+    send self(), {:ssh_cm, ref, {:exit_status, id, 0}}
+    send self(), {:ssh_cm, ref, {:closed, id}}
+    :success
+  end
+
+  def send(_ref, _id, _type, _data, _timeout) do
+    :ok
+  end
+
+  def send_eof(_ref, _id) do
+    :ok
+  end
+
+  def adjust_window(_ref, _id, _size) do
+    :ok
+  end
+end

--- a/lib/sshkit/ssh/dry_run/ssh_connection.ex
+++ b/lib/sshkit/ssh/dry_run/ssh_connection.ex
@@ -8,7 +8,6 @@ defmodule SSHKit.SSH.DryRun.SSHConnection do
     {:ok, @ssh_channel_id}
   end
 
-
   def exec(ref, id, command, _timeout) do
     Logger.info("Command: #{command}")
 

--- a/lib/sshkit/ssh/dry_run/ssh_connection.ex
+++ b/lib/sshkit/ssh/dry_run/ssh_connection.ex
@@ -8,9 +8,6 @@ defmodule SSHKit.SSH.DryRun.SSHConnection do
     {:ok, @ssh_channel_id}
   end
 
-  def close(_ref, _id) do
-    :ok
-  end
 
   def exec(ref, id, command, _timeout) do
     Logger.info("Command: #{command}")
@@ -20,15 +17,8 @@ defmodule SSHKit.SSH.DryRun.SSHConnection do
     :success
   end
 
-  def send(_ref, _id, _type, _data, _timeout) do
-    :ok
-  end
-
-  def send_eof(_ref, _id) do
-    :ok
-  end
-
-  def adjust_window(_ref, _id, _size) do
-    :ok
-  end
+  def close(_ref, _id), do: :ok
+  def send_eof(_ref, _id), do: :ok
+  def adjust_window(_ref, _id, _size), do: :ok
+  def send(_ref, _id, _type, _data, _timeout), do: :ok
 end

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -144,7 +144,7 @@ defmodule SSHKit.SSHTest do
       assert_received :closed_sandbox_connection
     end
 
-    test "its logs the closed when dry_run is enabled" do
+    test "log closing the connection when dry_run is enabled" do
       logged = capture_log fn ->
         {:ok, conn} = connect(@host, [user: @user, dry_run: true])
         assert close(conn) == :ok
@@ -180,7 +180,7 @@ defmodule SSHKit.SSHTest do
       assert_received :exec_sandbox_connection
     end
 
-    test "its logs the command execution when dry_run is enabled" do
+    test "log the command execution when dry_run is enabled" do
       logged = capture_log fn ->
         {:ok, conn} = connect(@host, [user: @user, dry_run: true])
         assert run(conn, "uptime") == {:ok, [], 0}

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -60,15 +60,7 @@ defmodule SSHKit.SSHTest do
       refute_received :closed_sandbox_connection
     end
 
-    test "its logs the connection when dry_run is enabled" do
-      logged = capture_log fn ->
-        connect(@host, [user: @user, dry_run: true])
-      end
-
-      assert logged =~ "[info]  Connect: #{@user}@#{@host}:22"
-    end
-
-    test "its logs the connection when dry_run is enabled and there is no user" do
+    test "log the connection when dry_run is enabled" do
       logged = capture_log fn ->
         connect(@host, [dry_run: true])
       end
@@ -76,7 +68,15 @@ defmodule SSHKit.SSHTest do
       assert logged =~ "[info]  Connect: #{@host}:22"
     end
 
-    test "its logs the connection when dry_run is enabled with a non-default port" do
+    test "log the connection when dry_run is enabled and there is a user" do
+      logged = capture_log fn ->
+        connect(@host, [user: @user, dry_run: true])
+      end
+
+      assert logged =~ "[info]  Connect: #{@user}@#{@host}:22"
+    end
+
+    test "log the connection when dry_run is enabled with a non-default port" do
       logged = capture_log fn ->
         connect(@host, [dry_run: true, port: 666])
       end

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -2,6 +2,7 @@ defmodule SSHKit.SSHTest do
   use ExUnit.Case, async: true
 
   import SSHKit.SSH
+  import ExUnit.CaptureLog
 
   defmodule SSHSandboxSuccess do
     def connect(_, _, _, _), do: {:ok, :sandbox}
@@ -57,6 +58,30 @@ defmodule SSHKit.SSHTest do
 
       assert connect(@host, options) == {:ok, conn}
       refute_received :closed_sandbox_connection
+    end
+
+    test "its logs the connection when dry_run is enabled" do
+      logged = capture_log fn ->
+        connect(@host, [user: @user, dry_run: true])
+      end
+
+      assert logged =~ "[info]  Connect: #{@user}@#{@host}:22"
+    end
+
+    test "its logs the connection when dry_run is enabled and there is no user" do
+      logged = capture_log fn ->
+        connect(@host, [dry_run: true])
+      end
+
+      assert logged =~ "[info]  Connect: #{@host}:22"
+    end
+
+    test "its logs the connection when dry_run is enabled with a non-default port" do
+      logged = capture_log fn ->
+        connect(@host, [dry_run: true, port: 666])
+      end
+
+      assert logged =~ "[info]  Connect: #{@host}:666"
     end
 
     @options [ssh_modules: %{ssh: SSHSandboxError, ssh_connection: :ssh_connection}]
@@ -118,6 +143,15 @@ defmodule SSHKit.SSHTest do
       assert close(conn) == :ok
       assert_received :closed_sandbox_connection
     end
+
+    test "its logs the closed when dry_run is enabled" do
+      logged = capture_log fn ->
+        {:ok, conn} = connect(@host, [user: @user, dry_run: true])
+        assert close(conn) == :ok
+      end
+
+      assert logged =~ "[info]  Disconnect: #{@user}@#{@host}:22"
+    end
   end
 
   describe "run/3" do
@@ -144,6 +178,15 @@ defmodule SSHKit.SSHTest do
       }
       assert run(conn, "uptime") == {:ok, :result}
       assert_received :exec_sandbox_connection
+    end
+
+    test "its logs the command execution when dry_run is enabled" do
+      logged = capture_log fn ->
+        {:ok, conn} = connect(@host, [user: @user, dry_run: true])
+        assert run(conn, "uptime") == {:ok, [], 0}
+      end
+
+      assert logged =~ "[info]  Command: uptime"
     end
 
     @options [ssh_modules: %{ssh: SSHSandboxSuccess, ssh_connection: SSHSandboxConnectionError}]

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -13,7 +13,7 @@ defmodule SSHKitFunctionalTest do
 
   def build_context(host) do
     overrides = [port: host.port, user: host.user, password: host.password]
-    SSHKit.context({host.ip, Keyword.merge(@defaults, overrides)})
+    SSHKit.context({host.ip, options(overrides)})
   end
 
   defp stdio(output, type) do


### PR DESCRIPTION
Adds an option `:dry_run` which  lets sshkit log commands, instead of actually executing them on a remote host.

---

* [x] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [x] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
