### PR TITLE
Update deprecated String methods for Elixir 1.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Presented in reverse chronological order.
 
 https://github.com/bitcrowd/sshkit.ex/compare/v0.0.3...HEAD
 
+* Fix Elixir 1.5 String deprecations. Removes Elixir 1.2 and below support.
+
 ### Deprecations:
 
 * Put deprecations here

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -168,6 +168,6 @@ defmodule SSHKit.SCP.Upload do
     value
     |> Bitwise.band(0o7777)
     |> Integer.to_string(8)
-    |> String.rjust(4, ?0)
+    |> String.pad_leading(4, "0")
   end
 end

--- a/test/support/functional_assertion_helpers.ex
+++ b/test/support/functional_assertion_helpers.ex
@@ -46,7 +46,7 @@ defmodule SSHKit.FunctionalAssertionHelpers do
   end
 
   def compare_command_output(conn, local, remote) do
-    local_output = local |> String.to_char_list |> :os.cmd |> to_string
+    local_output = local |> String.to_charlist |> :os.cmd |> to_string
     {:ok, [stdout: remote_output], 0} = SSH.run(conn, remote)
     assert local_output == remote_output
   end


### PR DESCRIPTION
This breaks compatibility with Elixir 1.2. Shouldn't be an issue given `mix.exs` calls out a minimum of 1.3 already.