### PR TITLE
Allow running non functional tests without docker

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,15 +1,22 @@
-unless Docker.ready? do
-  IO.puts """
-  It seems like Docker isn't running?
+excluded = Application.get_env(:ex_unit, :exclude)
+included = Application.get_env(:ex_unit, :include)
 
-  Please check:
+unless (:functional in excluded) && !(:functional in included) do
+  unless Docker.ready? do
+    IO.puts """
+    It seems like Docker isn't running?
 
-  1. Docker is installed: `docker version`
-  2. On OS X and Windows: `docker-machine start`
-  3. Environment is set up: `eval $(docker-machine env)`
-  """
+    Please check:
 
-  exit({:shutdown, 1})
+    1. Docker is installed: `docker version`
+    2. On OS X and Windows: `docker-machine start`
+    3. Environment is set up: `eval $(docker-machine env)`
+    """
+
+    exit({:shutdown, 1})
+  end
+
+  Docker.build!("sshkit-test-sshd", "test/support/docker")
 end
 
 shasum_command = SystemCommands.shasum_cmd()
@@ -25,7 +32,5 @@ rescue
     """
     exit({:shutdown, 1})
 end
-
-Docker.build!("sshkit-test-sshd", "test/support/docker")
 
 ExUnit.start()


### PR DESCRIPTION
Allow running non-functional tests without requiring Docker.

In particular, the following will no longer exit with an error if you're not running Docker:

```shell
mix test --exclude functional
```

The following will:

```shell
mix test --exclude functional --include functional
```

---

* [ ] Documented the change if necessary
* [ ] Tested this PRs change (with unit and/or functional tests)
* [ ] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
