### PR TITLE
Upgrade Alpine Linux Docker image

### DIFF
--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 
 # Set up an Alpine Linux machine running an SSH server.
 # Autogenerate missing host keys.


### PR DESCRIPTION
Upgrade the Docker image used for functional testing from `alpine:3.5` to `alpine:3.7`.

---

* [x] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [x] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.