### PR TITLE
[#103] Move SSHKit unit test into correct place

### DIFF
--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -135,7 +135,6 @@ defmodule SSHKit do
   context = SSHKit.context(hosts, options)
   ```
   """
-
   def context(hosts, shared_options \\ []) do
     hosts =
       hosts

--- a/test/sshkit/context_test.exs
+++ b/test/sshkit/context_test.exs
@@ -32,19 +32,7 @@ defmodule SSHKit.ContextTest do
       assert command =~ ~r/export CUSTOM="env variable"/
     end
 
-    test "build with overwritten env" do
-      command =
-        @empty
-        |> SSHKit.env(%{"NODE_ENV" => "production"})
-        |> SSHKit.env(%{"CI" => "true"})
-        |> Context.build("ls")
-
-      assert command =~ ~r/export CI="true"/
-      refute command =~ ~r/NODE_ENV/
-    end
-
     test "build with nil env" do
-
       command =
         %Context{@empty | env: nil}
         |> Context.build("ls")
@@ -54,7 +42,6 @@ defmodule SSHKit.ContextTest do
     end
 
     test "build with empty env" do
-
       command =
         %Context{@empty | env: %{}}
         |> Context.build("ls")

--- a/test/sshkit/sshkit_test.exs
+++ b/test/sshkit/sshkit_test.exs
@@ -4,6 +4,8 @@ defmodule SSHKitTest do
   alias SSHKit.Context
   alias SSHKit.Host
 
+  @empty %Context{hosts: []}
+
   @context_simple %Context{hosts: [
                     %Host{name: "10.0.0.1", options: []},
                     %Host{name: "10.0.0.2", options: []},
@@ -78,6 +80,17 @@ defmodule SSHKitTest do
       ]
       context = SSHKit.context(hosts, @options)
       assert context == expected_context
+    end
+  end
+
+  describe "env/2" do
+    test "overwrites existing env" do
+      context =
+        @empty
+        |> SSHKit.env(%{"NODE_ENV" => "production"})
+        |> SSHKit.env(%{"CI" => "true"})
+
+      assert context.env == %{"CI" => "true"}
     end
   end
 end


### PR DESCRIPTION
Fixes #103.

This test for `Context` was actually testing the SSHKit module and should therefore go into `sshkit_test.exs`. Plus, it did not need to `build` the context, just test the modified context only contains the last env provided to `SSHKit.env/2`.

PS: Trying to create smaller PRs @tessi 😃 

---

* [ ] Documented the change if necessary
* [x] Tested this PRs change (with unit and/or functional tests)
* [ ] Added this PRs change to CHANGELOG.md (in the `#master` section) if  necessary.
