### PR TITLE
[#100] Drop "dry-run" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,10 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.3...v0.1.0
 
 ### Potentially breaking changes:
 
-* Remove `:dry_run` option for now. Planning to reintroduce at a higher level.
+* Remove `:dry_run` option: Depending on how you're using SSHKit, "dry-run" could have a number of different meanings
+  * you may want to actually connect to the remote without changing anything or you may not want to establish a connection at all
+  * some steps in the flow you're dry-running may depend on things like directories created in a previous step which won't be there
+  * all in all, a "dry-run" feature is likely better handled at an application level which may know the dependencies between commands
 * Set `-H` option for `sudo` in order to get the expected value for `HOME`
 
 ### New features:


### PR DESCRIPTION
### Description

Add a bit of background for dropping the "dry-run" feature to the `CHANGELOG.md` like we discussed today.

### Motivation and Context

The changelog previously stated that we might re-introduce the feature again later, but after discussing it, it seems more appropriate for applications using SSHKit to implement such a feature if they need it.

Closes #100.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).