### PR TITLE
Make functional tests run faster

### DIFF
--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -1,5 +1,5 @@
 defmodule SSHKit.SCPFunctionalTest do
-  use SSHKit.FunctionalCase, async: false
+  use SSHKit.FunctionalCase, async: true
   import SSHKit.FunctionalAssertionHelpers
 
   alias SSHKit.SCP

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -4,7 +4,7 @@ defmodule SSHKitFunctionalTest do
   import SSHKit.FunctionalCaseHelpers
   import SSHKit.FunctionalAssertionHelpers
 
-  use SSHKit.FunctionalCase, async: false
+  use SSHKit.FunctionalCase, async: true
 
   @defaults [silently_accept_hosts: true, timeout: 5000]
 

--- a/test/support/functional_assertion_helpers.ex
+++ b/test/support/functional_assertion_helpers.ex
@@ -52,6 +52,12 @@ defmodule SSHKit.FunctionalAssertionHelpers do
   end
 
   def create_local_tmp_path do
-    Path.join(System.tmp_dir, "test_#{16 |> :crypto.strong_rand_bytes |> Base.url_encode64 |> binary_part(0, 16)}")
+    rand =
+      16
+      |> :crypto.strong_rand_bytes()
+      |> Base.url_encode64()
+      |> binary_part(0, 16)
+
+    Path.join(System.tmp_dir(), "sshkit-test-#{rand}")
   end
 end


### PR DESCRIPTION
### Description

#### Update `SSHKit` and `SSHKit.SCP` functional tests to be `async: true`

These tests are currently not run in concurrently with other tests. Both already use temp directories with randomly generated names for testing everything which touches the local system (downloads from a container).

However, to fully isolate them, we also need to avoid things like `File.cd!` which changes the working directory of all (test) processes and can cause parallel tests to fail.

Once they are made fully isolated, there is no need to set `async` to `false` anymore.

✅

Reported times for `mix test --only functional` showed a reduction from 35 s to 25 s on my machine, from 55 s to 39 s on Travis CI, when using `async: true`. Roughly a 28-30% improvement

#### 🚧 Question: Can we further isolate functional test processes?

The current assumption in our functional tests is that they take care to create temp directories whenever they wish to touch the local filesystem and that they clean up after themselves. We assume tests and SSHKit operations do not do anything completely crazy – which seems quite reasonable and is also done in the [Elixir test suite](https://github.com/elixir-lang/elixir/blob/8f0fe3d23f11e9d9461e3bcf6dfab72eb28526af/lib/elixir/test/elixir/file_test.exs#L13-L17).

However, maybe we can make functional tests even safer, isolating the local filesystem?
Maybe we can isolate functional tests so they're safe to use `File.cd` and the likes?

Brainstorming: run in containers, chroot, memory filesystem, filesystem overlay, mock `Elixir.File`…

❔ 

### Motivation and Context

It takes about 35 seconds to run our functional tests on the current `master`. Ideally they should run faster for a more pleasant development experience and quicker feedback.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
