### PR TITLE
Improve functional tests (part I)

### DIFF
--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -1,6 +1,5 @@
 defmodule SSHKit.SCPFunctionalTest do
   use SSHKit.FunctionalCase, async: true
-  import SSHKit.FunctionalAssertionHelpers
 
   alias SSHKit.SCP
   alias SSHKit.SSH

--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -4,53 +4,49 @@ defmodule SSHKit.SCPFunctionalTest do
   alias SSHKit.SCP
   alias SSHKit.SSH
 
-  @defaults [silently_accept_hosts: true]
+  @bootconf [user: "me", password: "pass"]
 
   describe "upload/4" do
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "sends a file", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures/local.txt"
       remote = "file.txt"
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote)
         assert verify_transfer(conn, local, remote)
       end
     end
 
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "recursive: true", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures"
-      remote = "/home/#{host.user}/destination"
+      remote = "/home/#{host.options[:user]}/destination"
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote, recursive: true)
         assert verify_transfer(conn, local, remote)
       end
     end
 
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "preserve: true", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures/local.txt"
       remote = "file.txt"
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_mtime(conn, local, remote)
       end
     end
 
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "recursive: true, preserve: true", %{hosts: [host]} do
-      options = [port: host.port, user: host.user, password: host.password]
       local = "test/fixtures/"
-      remote = "/home/#{host.user}/destination"
+      remote = "/home/#{host.options[:user]}/destination"
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote, recursive: true, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_mtime(conn, local, remote)
@@ -59,40 +55,37 @@ defmodule SSHKit.SCPFunctionalTest do
   end
 
   describe "download/4" do
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "gets a file", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures/remote.txt"
       local = create_local_tmp_path()
       on_exit fn -> File.rm(local) end
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local)
         assert verify_transfer(conn, local, remote)
       end
     end
 
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "recursive: true", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures"
       local = create_local_tmp_path()
       on_exit fn -> File.rm_rf(local) end
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local, recursive: true)
         assert verify_transfer(conn, local, remote)
       end
     end
 
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "preserve: true", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures/remote.txt"
       local = create_local_tmp_path()
       on_exit fn -> File.rm(local) end
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_atime(conn, local, remote)
@@ -100,14 +93,13 @@ defmodule SSHKit.SCPFunctionalTest do
       end
     end
 
-    @tag boot: 1
+    @tag boot: [@bootconf]
     test "recursive: true, preserve: true", %{hosts: [host]} do
-      options = @defaults ++ [port: host.port, user: host.user, password: host.password]
       remote = "/fixtures"
       local = create_local_tmp_path()
       on_exit fn -> File.rm_rf(local) end
 
-      SSH.connect host.ip, options, fn(conn) ->
+      SSH.connect host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local, recursive: true, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_atime(conn, local, remote)

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -21,7 +21,7 @@ defmodule SSHKitFunctionalTest do
     context = SSHKit.context(host)
 
     [{:ok, output, status}] = SSHKit.run(context, "pwd")
-    assert status == 0, stderr(output)
+    assert status == 0
     assert stdout(output) == "/home/me\n"
 
     [{:ok, output, status}] = SSHKit.run(context, "ls non-existing")
@@ -41,7 +41,7 @@ defmodule SSHKitFunctionalTest do
       |> SSHKit.env(%{"PATH" => "$HOME/.rbenv/shims:$PATH", "NODE_ENV" => "production"})
       |> SSHKit.run("env")
 
-    assert status == 0, stderr(output)
+    assert status == 0
 
     output = stdout(output)
     assert output =~ "NODE_ENV=production"
@@ -60,7 +60,7 @@ defmodule SSHKitFunctionalTest do
 
     [{:ok, output, status}] = SSHKit.run(context, "ls -la")
 
-    assert status == 0, stderr(output)
+    assert status == 0
 
     output = stdout(output)
     assert output =~ ~r/drwx--S---\s+2\s+me\s+me\s+4096.+my_dir/
@@ -76,7 +76,7 @@ defmodule SSHKitFunctionalTest do
 
     [{:ok, output, status}] = SSHKit.run(context, "pwd")
 
-    assert status == 0, stderr(output)
+    assert status == 0
     assert stdout(output) == "/var/log\n"
   end
 
@@ -93,7 +93,7 @@ defmodule SSHKitFunctionalTest do
 
     [{:ok, output, status}] = SSHKit.run(context, "id -un")
 
-    assert status == 0, stderr(output)
+    assert status == 0
     assert stdout(output) == "despicable_me\n"
   end
 
@@ -113,13 +113,13 @@ defmodule SSHKitFunctionalTest do
 
     [{:ok, output, status}] = SSHKit.run(context, "id -gn")
 
-    assert status == 0, stderr(output)
+    assert status == 0
     assert stdout(output) == "villains\n"
   end
 
   describe "upload/3" do
     @tag boot: [@bootconf, @bootconf]
-    test "sends a file", %{hosts: hosts} do
+    test "uploads a file", %{hosts: hosts} do
       local = "test/fixtures/local.txt"
 
       context = SSHKit.context(hosts)

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -1,9 +1,6 @@
 defmodule SSHKitFunctionalTest do
   @moduledoc false
 
-  import SSHKit.FunctionalCaseHelpers
-  import SSHKit.FunctionalAssertionHelpers
-
   use SSHKit.FunctionalCase, async: true
 
   @defaults [silently_accept_hosts: true, timeout: 5000]

--- a/test/support/functional_case.ex
+++ b/test/support/functional_case.ex
@@ -14,6 +14,9 @@ defmodule SSHKit.FunctionalCase do
 
   using do
     quote do
+      import SSHKit.FunctionalCaseHelpers
+      import SSHKit.FunctionalAssertionHelpers
+
       @moduletag :functional
     end
   end

--- a/test/support/functional_case.ex
+++ b/test/support/functional_case.ex
@@ -57,14 +57,8 @@ defmodule SSHKit.FunctionalCase do
     user = options[:user]
     password = options[:password]
 
-    if user != nil do
-      adduser!(host, user)
-      keygen!(host, user)
-    end
-
-    if user != nil && password != nil do
-      chpasswd!(host, user, password)
-    end
+    if user != nil, do: adduser!(host, user)
+    if user != nil && password != nil, do: chpasswd!(host, user, password)
 
     %Host{host | options: options}
   end


### PR DESCRIPTION
### Description

####  Update functional test tag `:boot`

Change `:boot` tag format & allow overriding host options via the tag:

```
# before:
@tag boot: <number>

# after:
@tag boot: [<options>, ...]

# example:
@tag boot: [[user: "tester", password: "secret"]]
```

Additionally, apply common defaults used for testing to all hosts, i.e. the `:silently_accept_hosts` and `:timeout` options.

The returned host maps are now proper structs with fields that are compatible with `SSHKit.host/1`. This means we can pass them to `SSHKit.context` directly.

####  Do not generate keys for all functional test hosts

At the moment, we are not using the SSH keys at all. When we use them, we should generate them selectively for those tests that require it.

This carves another ~22% off of the overall test time. (Locally tests now run in ~17 s while they took 35 s before I started improving the functional tests.)

### Motivation and Context

<!---
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
