### PR TITLE
Disable Docker update on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
       otp_release: 20.2
       services: docker
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-
 script:
   - mix credo --strict
   - mix test --exclude functional


### PR DESCRIPTION
### Description

Seems like we no longer need the manual update and can save some time. I've left the commented-out config lines in the file and added a link to the documentation though, in case something crops up again.

### Motivation and Context

Updating apt caches and `docker-ce` takes around 13 s on each Travis CI job. We've added the `before_install` hook in the past because we ran into issues when running tests on Travis CI.

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
