### PR TITLE
[#115] Test more complex combinations of SSHKit context options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.3...v0.1.0
   * some steps in the flow you're dry-running may depend on things like directories created in a previous step which won't be there
   * all in all, a "dry-run" feature is likely better handled at an application level which may know the dependencies between commands
 * Set `-H` option for `sudo` in order to get the expected value for `HOME`
+* Export context environment variables directly before the supplied command in `SSHKit.Context.build/2`
+  * this could potentially result in different behavior for code that sets environment variables consumed by the other commands in the context
+  * those cases should be rare though and the new behavior seems closer to what most would expect when using contexts
 
 ### New features:
 
@@ -50,6 +53,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.3...v0.1.0
 
 * Fix error handling in `SSHKit.SSH.Channel.send/4` when sending stream data
 * Context properly handles the case where env is set to an empty map
+* Fix environment variables export in contexts with user, group, umask, path and env
 
 ## `0.0.3` (2017-07-13)
 

--- a/lib/sshkit/context.ex
+++ b/lib/sshkit/context.ex
@@ -23,13 +23,11 @@ defmodule SSHKit.Context do
 
   ## Examples
 
-  ```
-  iex> %SSHKit.Context{path: "/var/www"} |> SSHKit.Context.build("ls")
-  "cd /var/www && /usr/bin/env ls"
+      iex> %SSHKit.Context{path: "/var/www"} |> SSHKit.Context.build("ls")
+      "cd /var/www && /usr/bin/env ls"
 
-  iex> %SSHKit.Context{user: "me"} |> SSHKit.Context.build("whoami")
-  "sudo -H -n -u me -- sh -c '/usr/bin/env whoami'"
-  ```
+      iex> %SSHKit.Context{user: "me"} |> SSHKit.Context.build("whoami")
+      "sudo -H -n -u me -- sh -c '/usr/bin/env whoami'"
   """
   def build(context, command) do
     "/usr/bin/env #{command}"

--- a/lib/sshkit/context.ex
+++ b/lib/sshkit/context.ex
@@ -33,8 +33,8 @@ defmodule SSHKit.Context do
   """
   def build(context, command) do
     "/usr/bin/env #{command}"
-    |> sudo(context.user, context.group)
     |> export(context.env)
+    |> sudo(context.user, context.group)
     |> umask(context.umask)
     |> cd(context.path)
   end

--- a/test/sshkit/context_test.exs
+++ b/test/sshkit/context_test.exs
@@ -79,5 +79,18 @@ defmodule SSHKit.ContextTest do
 
       assert command == "cd /var/www && /usr/bin/env ls -l"
     end
+
+    test "with all options" do
+      command =
+        @empty
+        |> Map.put(:path, "/app")
+        |> Map.put(:user, "me")
+        |> Map.put(:group, "crew")
+        |> Map.put(:umask, "007")
+        |> Map.put(:env, %{"HOME" => "/home/me"})
+        |> Context.build("cp $HOME/conf .")
+
+      assert command == ~S{cd /app && umask 007 && sudo -H -n -u me -g crew -- sh -c '(export HOME="/home/me" && /usr/bin/env cp $HOME/conf .)'}
+    end
   end
 end

--- a/test/sshkit/context_test.exs
+++ b/test/sshkit/context_test.exs
@@ -5,6 +5,8 @@ defmodule SSHKit.ContextTest do
 
   @empty %Context{hosts: []}
 
+  doctest Context
+
   describe "build/2" do
     test "with user" do
       command =

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -25,13 +25,13 @@ defmodule SSHKitFunctionalTest do
       assert status == 0
       assert stdout(output) == "/home/me\n"
 
-      [{:ok, output, status}] = SSHKit.run(context, "ls non-existing")
+      [{:ok, output, status}] = SSHKit.run(context, "ls nonexistent")
       assert status == 1
-      assert stderr(output) =~ "ls: non-existing: No such file or directory"
+      assert stderr(output) =~ "ls: nonexistent: No such file or directory"
 
-      [{:ok, output, status}] = SSHKit.run(context, "does-not-exist")
+      [{:ok, output, status}] = SSHKit.run(context, "nonexistent")
       assert status == 127
-      assert stderr(output) =~ "'does-not-exist': No such file or directory"
+      assert stderr(output) =~ "'nonexistent': No such file or directory"
     end
 
     @tag boot: [@bootconf]
@@ -45,8 +45,8 @@ defmodule SSHKitFunctionalTest do
       assert status == 0
 
       output = stdout(output)
-      assert output =~ "NODE_ENV=production"
-      assert output =~ ~r/PATH=.*\/\.rbenv\/shims:/
+      assert output =~ ~r/^NODE_ENV=production$/m
+      assert output =~ ~r/^PATH=\/home\/me\/.rbenv\/shims:.*$/m
     end
 
     @tag boot: [@bootconf]
@@ -64,8 +64,8 @@ defmodule SSHKitFunctionalTest do
       assert status == 0
 
       output = stdout(output)
-      assert output =~ ~r/drwx--S---\s+2\s+me\s+me\s+4096.+my_dir/
-      assert output =~ ~r/-rw-------\s+1\s+me\s+me\s+0.+my_file/
+      assert output =~ ~r/^drwx--S---\s+2\s+me\s+me\s+4096.+\smy_dir$/m
+      assert output =~ ~r/^-rw-------\s+1\s+me\s+me\s+0.+\smy_file$/m
     end
 
     @tag boot: [@bootconf]
@@ -84,7 +84,6 @@ defmodule SSHKitFunctionalTest do
     @tag boot: [@bootconf]
     test "with user", %{hosts: [host]} do
       add_user_to_group!(host, host.options[:user], "passwordless-sudoers")
-
       adduser!(host, "despicable_me")
 
       context =

--- a/test/support/functional_assertion_helpers.ex
+++ b/test/support/functional_assertion_helpers.ex
@@ -1,6 +1,8 @@
 defmodule SSHKit.FunctionalAssertionHelpers do
   @moduledoc false
+
   import ExUnit.Assertions
+
   alias SSHKit.Context
   alias SSHKit.SSH
 

--- a/test/support/functional_case_helpers.ex
+++ b/test/support/functional_case_helpers.ex
@@ -1,25 +1,29 @@
 defmodule SSHKit.FunctionalCaseHelpers do
   @moduledoc false
 
-  def adduser!(_host = %{id: id}, username) do
-    Docker.exec!([], id, "adduser", ["-D", username])
+  def exec!(_host = %{id: id}, command, args \\ []) do
+    Docker.exec!([], id, command, args)
   end
 
-  def addgroup!(_host = %{id: id}, groupname) do
-    Docker.exec!([], id, "addgroup", [groupname])
+  def adduser!(host, username) do
+    exec!(host, "adduser", ["-D", username])
   end
 
-  def add_user_to_group!(_host = %{id: id}, username, groupname) do
-    Docker.exec!([], id, "addgroup", [username, groupname])
+  def addgroup!(host, groupname) do
+    exec!(host, "addgroup", [groupname])
   end
 
-  def chpasswd!(_host = %{id: id}, username, password) do
+  def add_user_to_group!(host, username, groupname) do
+    exec!(host, "addgroup", [username, groupname])
+  end
+
+  def chpasswd!(host, username, password) do
     command = "echo #{username}:#{password} | chpasswd 2>&1"
-    Docker.exec!([], id, "sh", ["-c", command])
+    exec!(host, "sh", ["-c", command])
   end
 
-  def keygen!(_host = %{id: id}, username) do
-    Docker.exec!([], id, "sh", ["-c", "ssh-keygen -b 1024 -f /tmp/#{username} -N '' -C \"#{username}@$(hostname)\""])
-    Docker.exec!([], id, "sh", ["-c", "cat /tmp/#{username}.pub > /home/#{username}/.ssh/authorized_keys"])
+  def keygen!(host, username) do
+    exec!(host, "sh", ["-c", "ssh-keygen -b 1024 -f /tmp/#{username} -N '' -C \"#{username}@$(hostname)\""])
+    exec!(host, "sh", ["-c", "cat /tmp/#{username}.pub > /home/#{username}/.ssh/authorized_keys"])
   end
 end


### PR DESCRIPTION
### Description

* Add test case using a context with all of
  * `:user`,
  * `:group`,
  * `:umask`,
  * `:path` and
  * `:env`.
* Fix unexpected behavior regarding environment variables in such cases.

### Motivation and Context

> At the moment we're not testing combinations of different SSHKit options. I would therefore like to see functional test cases covering these more complex interactions of SSHKit path, user, group, umask and env.

— see https://github.com/bitcrowd/sshkit.ex/issues/115

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
