### PR TITLE
Use `mix format`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
       services: docker
 
 script:
+  - mix format --check-formatted
   - mix credo --strict
   - mix test --exclude functional
   - mix test --only functional

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -357,9 +357,11 @@ defmodule SSHKit do
     remote_path = build_remote_path(context, as_path)
 
     run = fn host ->
-      {:ok, res} = SSH.connect host.name, host.options, fn conn ->
-        SCP.upload(conn, path, remote_path, options)
-      end
+      {:ok, res} =
+        SSH.connect(host.name, host.options, fn conn ->
+          SCP.upload(conn, path, remote_path, options)
+        end)
+
       res
     end
 
@@ -402,9 +404,11 @@ defmodule SSHKit do
     local = Keyword.get(options, :as, Path.basename(path))
 
     run = fn host ->
-      {:ok, res} = SSH.connect host.name, host.options, fn conn ->
-        SCP.download(conn, remote, local, options)
-      end
+      {:ok, res} =
+        SSH.connect(host.name, host.options, fn conn ->
+          SCP.download(conn, remote, local, options)
+        end)
+
       res
     end
 

--- a/lib/sshkit/context.ex
+++ b/lib/sshkit/context.ex
@@ -15,7 +15,7 @@ defmodule SSHKit.Context do
 
   import SSHKit.Utils
 
-  defstruct [hosts: [], env: nil, path: nil, umask: nil, user: nil, group: nil]
+  defstruct hosts: [], env: nil, path: nil, umask: nil, user: nil, group: nil
 
   @doc """
   Compiles an executable command string for running the given `command`
@@ -40,12 +40,19 @@ defmodule SSHKit.Context do
   end
 
   defp sudo(command, nil, nil), do: command
-  defp sudo(command, username, nil), do: "sudo -H -n -u #{username} -- sh -c #{shellquote(command)}"
-  defp sudo(command, nil, groupname), do: "sudo -H -n -g #{groupname} -- sh -c #{shellquote(command)}"
-  defp sudo(command, username, groupname), do: "sudo -H -n -u #{username} -g #{groupname} -- sh -c #{shellquote(command)}"
+
+  defp sudo(command, username, nil),
+    do: "sudo -H -n -u #{username} -- sh -c #{shellquote(command)}"
+
+  defp sudo(command, nil, groupname),
+    do: "sudo -H -n -g #{groupname} -- sh -c #{shellquote(command)}"
+
+  defp sudo(command, username, groupname),
+    do: "sudo -H -n -u #{username} -g #{groupname} -- sh -c #{shellquote(command)}"
 
   defp export(command, nil), do: command
   defp export(command, env) when env == %{}, do: command
+
   defp export(command, env) do
     exports = Enum.map_join(env, " ", fn {name, value} -> "#{name}=\"#{value}\"" end)
     "(export #{exports} && #{command})"

--- a/lib/sshkit/scp/download.ex
+++ b/lib/sshkit/scp/download.ex
@@ -40,10 +40,13 @@ defmodule SSHKit.SCP.Download do
       case message do
         {:data, _, 0, data} ->
           process_data(state, data, options)
+
         {:exit_status, _, status} ->
           exited(options, state, status)
+
         {:eof, _} ->
           eof(options, state)
+
         {:closed, _} ->
           closed(options, state)
       end
@@ -54,6 +57,7 @@ defmodule SSHKit.SCP.Download do
     case state do
       {:next, path, stack, attrs, buffer} ->
         next(options, path, stack, attrs, buffer <> data)
+
       {:read, path, stack, attrs, buffer} ->
         read(options, path, stack, attrs, buffer <> data)
     end
@@ -192,7 +196,7 @@ defmodule SSHKit.SCP.Download do
     atime = :calendar.gregorian_seconds_to_datetime(@epoch + atime)
     mtime = :calendar.gregorian_seconds_to_datetime(@epoch + mtime)
     {:ok, file_info} = File.stat(path)
-    :ok = File.write_stat(path, %{file_info| mtime: mtime, atime: atime}, [:posix])
+    :ok = File.write_stat(path, %{file_info | mtime: mtime, atime: atime}, [:posix])
   end
 
   @tfmt ~S"(T)(0|[1-9]\d*) (0|[1-9]\d{0,5}) (0|[1-9]\d*) (0|[1-9]\d{0,5})"
@@ -205,14 +209,19 @@ defmodule SSHKit.SCP.Download do
     case Regex.run(@dfmt, value, capture: :all_but_first) do
       ["T", mtime, mtus, atime, atus] ->
         {"T", dec(mtime), dec(mtus), dec(atime), dec(atus)}
+
       [chr, _, _, name] when chr in ["C", "D"] and name in ["/", "..", "."] ->
         nil
+
       ["C", mode, len, name] ->
         {"C", oct(mode), dec(len), name}
+
       ["D", mode, len, name] ->
         {"D", oct(mode), dec(len), name}
+
       ["E"] ->
         {"E"}
+
       nil ->
         nil
     end

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -48,25 +48,43 @@ defmodule SSHKit.SCP.Upload do
   defp connection_handler(options) do
     fn message, state ->
       case message do
-        {:data, _, 0, <<@warning, data :: binary>>} -> warning(options, state, data)
-        {:data, _, 0, <<@fatal, data :: binary>>} -> fatal(options, state, data)
+        {:data, _, 0, <<@warning, data::binary>>} ->
+          warning(options, state, data)
+
+        {:data, _, 0, <<@fatal, data::binary>>} ->
+          fatal(options, state, data)
+
         {:data, _, 0, <<@normal>>} ->
           handle_data(state, options)
+
         {:data, _, 0, data} ->
           handle_error_data(state, options, data)
-        {:exit_status, _, status} -> exited(options, state, status)
-        {:eof, _} -> eof(options, state)
-        {:closed, _} -> closed(options, state)
+
+        {:exit_status, _, status} ->
+          exited(options, state, status)
+
+        {:eof, _} ->
+          eof(options, state)
+
+        {:closed, _} ->
+          closed(options, state)
       end
     end
   end
 
   defp handle_data(state, options) do
     case state do
-      {:next, cwd, stack, errs} -> next(options, cwd, stack, errs)
-      {:directory, name, stat, cwd, stack, errs} -> directory(options, name, stat, cwd, stack, errs)
-      {:regular, name, stat, cwd, stack, errs} -> regular(options, name, stat, cwd, stack, errs)
-      {:write, name, stat, cwd, stack, errs} -> write(options, name, stat, cwd, stack, errs)
+      {:next, cwd, stack, errs} ->
+        next(options, cwd, stack, errs)
+
+      {:directory, name, stat, cwd, stack, errs} ->
+        directory(options, name, stat, cwd, stack, errs)
+
+      {:regular, name, stat, cwd, stack, errs} ->
+        regular(options, name, stat, cwd, stack, errs)
+
+      {:write, name, stat, cwd, stack, errs} ->
+        write(options, name, stat, cwd, stack, errs)
     end
   end
 
@@ -89,10 +107,11 @@ defmodule SSHKit.SCP.Upload do
     path = Path.join(cwd, name)
     stat = File.stat!(path, time: :posix)
 
-    stack = case stat.type do
-      :directory -> [File.ls!(path) | [rest | dirs]]
-      :regular -> [rest | dirs]
-    end
+    stack =
+      case stat.type do
+        :directory -> [File.ls!(path) | [rest | dirs]]
+        :regular -> [rest | dirs]
+      end
 
     if Keyword.get(options, :preserve, false) do
       time(options, stat.type, name, stat, cwd, stack, errs)
@@ -129,7 +148,8 @@ defmodule SSHKit.SCP.Upload do
   end
 
   defp exited(_, {_, _, _, errs}, status) do
-    {:halt, {:error, "SCP exited before completing the transfer (#{status}): #{Enum.join(errs, ", ")}"}}
+    {:halt,
+     {:error, "SCP exited before completing the transfer (#{status}): #{Enum.join(errs, ", ")}"}}
   end
 
   defp eof(_, state) do

--- a/lib/sshkit/ssh.ex
+++ b/lib/sshkit/ssh.ex
@@ -72,7 +72,9 @@ defmodule SSHKit.SSH do
         after
           :ok = close(conn)
         end
-      other -> other
+
+      other ->
+        other
     end
   end
 
@@ -131,8 +133,10 @@ defmodule SSHKit.SSH do
           channel
           |> Channel.loop(timeout, acc, fun)
           |> elem(1)
+
         :failure ->
           {:error, :failure}
+
         err ->
           err
       end
@@ -140,18 +144,23 @@ defmodule SSHKit.SSH do
   end
 
   defp capture(message, acc = {buffer, status}) do
-    next = case message do
-      {:data, _, 0, data} ->
-        {[{:stdout, data} | buffer], status}
-      {:data, _, 1, data} ->
-        {[{:stderr, data} | buffer], status}
-      {:exit_status, _, code} ->
-        {buffer, code}
-      {:closed, _} ->
-        {:ok, Enum.reverse(buffer), status}
-      _ ->
-        acc
-    end
+    next =
+      case message do
+        {:data, _, 0, data} ->
+          {[{:stdout, data} | buffer], status}
+
+        {:data, _, 1, data} ->
+          {[{:stderr, data} | buffer], status}
+
+        {:exit_status, _, code} ->
+          {buffer, code}
+
+        {:closed, _} ->
+          {:ok, Enum.reverse(buffer), status}
+
+        _ ->
+          acc
+      end
 
     {:cont, next}
   end

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -93,8 +93,8 @@ defmodule SSHKit.SSH.Channel do
 
   def send(channel, type, data, timeout) do
     Enum.reduce_while(data, :ok, fn
-      (datum, :ok) -> {:cont, send(channel, type, datum, timeout)}
-      (_, err) -> {:halt, err}
+      datum, :ok -> {:cont, send(channel, type, datum, timeout)}
+      _, err -> {:halt, err}
     end)
   end
 
@@ -227,7 +227,9 @@ defmodule SSHKit.SSH.Channel do
           :ok = ljust(channel, msg)
           loop(channel, timeout, fun.(msg, acc), fun)
         end
-      err -> halt(channel, err)
+
+      err ->
+        halt(channel, err)
     end
   end
 

--- a/lib/sshkit/ssh/connection.ex
+++ b/lib/sshkit/ssh/connection.ex
@@ -36,18 +36,21 @@ defmodule SSHKit.SSH.Connection do
   Returns `{:ok, conn}` on success, `{:error, reason}` otherwise.
   """
   def open(host, options \\ [])
+
   def open(nil, _) do
     {:error, "No host given."}
   end
+
   def open(host, options) when is_binary(host) do
     open(to_charlist(host), options)
   end
+
   def open(host, options) do
     {details, opts} = extract(options)
 
-    port    = details[:port]
+    port = details[:port]
     timeout = details[:timeout]
-    impl    = details[:impl]
+    impl = details[:impl]
 
     case impl.connect(host, port, opts, timeout) do
       {:ok, ref} -> {:ok, build(host, port, opts, ref, impl)}

--- a/lib/sshkit/utils.ex
+++ b/lib/sshkit/utils.ex
@@ -8,15 +8,18 @@ defmodule SSHKit.Utils do
   def charlistify(value) when is_list(value) do
     Enum.map(value, &charlistify/1)
   end
+
   def charlistify(value) when is_tuple(value) do
     value
     |> Tuple.to_list()
     |> charlistify()
     |> List.to_tuple()
   end
+
   def charlistify(value) when is_binary(value) do
     to_charlist(value)
   end
+
   def charlistify(value) do
     value
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,18 +5,20 @@ defmodule SSHKit.Mixfile do
   @source "https://github.com/bitcrowd/sshkit.ex"
 
   def project do
-    [app: :sshkit,
-     name: "sshkit",
-     version: @version,
-     elixir: "~> 1.5",
-     elixirc_paths: elixirc_paths(Mix.env),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     source_url: @source,
-     docs: [source_ref: "v#{@version}", main: "readme", extras: ["README.md"]],
-     description: description(),
-     deps: deps(),
-     package: package()]
+    [
+      app: :sshkit,
+      name: "sshkit",
+      version: @version,
+      elixir: "~> 1.5",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      source_url: @source,
+      docs: [source_ref: "v#{@version}", main: "readme", extras: ["README.md"]],
+      description: description(),
+      deps: deps(),
+      package: package()
+    ]
   end
 
   def application do
@@ -24,10 +26,12 @@ defmodule SSHKit.Mixfile do
   end
 
   defp deps do
-    [{:credo, "~> 0.7", runtime: false, only: [:dev, :test]},
-     {:ex_doc, "~> 0.14", runtime: false, only: [:dev]},
-     {:inch_ex, "~> 0.5", runtime: false, only: [:dev, :test]},
-     {:mox, "~> 0.3", only: :test}]
+    [
+      {:credo, "~> 0.7", runtime: false, only: [:dev, :test]},
+      {:ex_doc, "~> 0.14", runtime: false, only: [:dev]},
+      {:inch_ex, "~> 0.5", runtime: false, only: [:dev, :test]},
+      {:mox, "~> 0.3", only: :test}
+    ]
   end
 
   defp description do
@@ -35,11 +39,13 @@ defmodule SSHKit.Mixfile do
   end
 
   defp package do
-    [maintainers: ["bitcrowd", "Paul Meinhardt", "Paulo Diniz", "Philipp Tessenow"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => @source}]
+    [
+      maintainers: ["bitcrowd", "Paul Meinhardt", "Paulo Diniz", "Philipp Tessenow"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source}
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/sshkit/scp/command_test.exs
+++ b/test/sshkit/scp/command_test.exs
@@ -63,7 +63,8 @@ defmodule SSHKit.SCP.CommandTest do
     end
 
     test "constructs preserving and recursive download commands" do
-      assert build(:download, @path, preserve: true, recursive: true) == "scp -f -p -r #{@escaped}"
+      assert build(:download, @path, preserve: true, recursive: true) ==
+               "scp -f -p -r #{@escaped}"
     end
   end
 end

--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -12,10 +12,10 @@ defmodule SSHKit.SCPFunctionalTest do
       local = "test/fixtures/local.txt"
       remote = "file.txt"
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote)
         assert verify_transfer(conn, local, remote)
-      end
+      end)
     end
 
     @tag boot: [@bootconf]
@@ -23,10 +23,10 @@ defmodule SSHKit.SCPFunctionalTest do
       local = "test/fixtures"
       remote = "/home/#{host.options[:user]}/destination"
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote, recursive: true)
         assert verify_transfer(conn, local, remote)
-      end
+      end)
     end
 
     @tag boot: [@bootconf]
@@ -34,11 +34,11 @@ defmodule SSHKit.SCPFunctionalTest do
       local = "test/fixtures/local.txt"
       remote = "file.txt"
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_mtime(conn, local, remote)
-      end
+      end)
     end
 
     @tag boot: [@bootconf]
@@ -46,11 +46,11 @@ defmodule SSHKit.SCPFunctionalTest do
       local = "test/fixtures/"
       remote = "/home/#{host.options[:user]}/destination"
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.upload(conn, local, remote, recursive: true, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_mtime(conn, local, remote)
-      end
+      end)
     end
   end
 
@@ -59,52 +59,52 @@ defmodule SSHKit.SCPFunctionalTest do
     test "gets a file", %{hosts: [host]} do
       remote = "/fixtures/remote.txt"
       local = create_local_tmp_path()
-      on_exit fn -> File.rm(local) end
+      on_exit(fn -> File.rm(local) end)
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local)
         assert verify_transfer(conn, local, remote)
-      end
+      end)
     end
 
     @tag boot: [@bootconf]
     test "recursive: true", %{hosts: [host]} do
       remote = "/fixtures"
       local = create_local_tmp_path()
-      on_exit fn -> File.rm_rf(local) end
+      on_exit(fn -> File.rm_rf(local) end)
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local, recursive: true)
         assert verify_transfer(conn, local, remote)
-      end
+      end)
     end
 
     @tag boot: [@bootconf]
     test "preserve: true", %{hosts: [host]} do
       remote = "/fixtures/remote.txt"
       local = create_local_tmp_path()
-      on_exit fn -> File.rm(local) end
+      on_exit(fn -> File.rm(local) end)
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_atime(conn, local, remote)
         assert verify_mtime(conn, local, remote)
-      end
+      end)
     end
 
     @tag boot: [@bootconf]
     test "recursive: true, preserve: true", %{hosts: [host]} do
       remote = "/fixtures"
       local = create_local_tmp_path()
-      on_exit fn -> File.rm_rf(local) end
+      on_exit(fn -> File.rm_rf(local) end)
 
-      SSH.connect host.name, host.options, fn conn ->
+      SSH.connect(host.name, host.options, fn conn ->
         assert :ok = SCP.download(conn, remote, local, recursive: true, preserve: true)
         assert verify_mode(conn, local, remote)
         assert verify_atime(conn, local, remote)
         assert verify_mtime(conn, local, remote)
-      end
+      end)
     end
   end
 end

--- a/test/sshkit/ssh/channel_test.exs
+++ b/test/sshkit/ssh/channel_test.exs
@@ -8,7 +8,7 @@ defmodule SSHKit.SSH.ChannelTest do
   alias SSHKit.SSH.Connection
 
   setup do
-    Mox.verify_on_exit!
+    Mox.verify_on_exit!()
 
     conn = %Connection{ref: :test_connection, impl: Connection.ImplMock}
     chan = %Channel{connection: conn, type: :session, id: 1, impl: Channel.ImplMock}
@@ -18,7 +18,8 @@ defmodule SSHKit.SSH.ChannelTest do
 
   describe "open/2" do
     test "opens a channel on a connection", %{conn: conn, impl: impl} do
-      impl |> expect(:session_channel, fn (connection_ref, ini_window_size, max_packet_size, timeout) ->
+      impl
+      |> expect(:session_channel, fn connection_ref, ini_window_size, max_packet_size, timeout ->
         assert connection_ref == conn.ref
         assert ini_window_size == 128 * 1024
         assert max_packet_size == 32 * 1024
@@ -29,15 +30,16 @@ defmodule SSHKit.SSH.ChannelTest do
       {:ok, chan} = open(conn, impl: impl)
 
       assert chan == %Channel{
-        connection: conn,
-        type:       :session,
-        id:         0,
-        impl:       impl
-      }
+               connection: conn,
+               type: :session,
+               id: 0,
+               impl: impl
+             }
     end
 
     test "opens a channel with a specific timeout", %{conn: conn, impl: impl} do
-      impl |> expect(:session_channel, fn (_, _, _, timeout) ->
+      impl
+      |> expect(:session_channel, fn _, _, _, timeout ->
         assert timeout == 3000
         {:ok, 0}
       end)
@@ -46,14 +48,15 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "returns an error if channel cannot be opened", %{conn: conn, impl: impl} do
-      impl |> expect(:session_channel, fn (_, _, _, _) -> {:error, :timeout} end)
+      impl |> expect(:session_channel, fn _, _, _, _ -> {:error, :timeout} end)
       assert open(conn, impl: impl) == {:error, :timeout}
     end
   end
 
   describe "close/1" do
     test "closes the channel", %{chan: chan, impl: impl} do
-      impl |> expect(:close, fn (connection_ref, channel_id) ->
+      impl
+      |> expect(:close, fn connection_ref, channel_id ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
         :ok
@@ -65,7 +68,8 @@ defmodule SSHKit.SSH.ChannelTest do
 
   describe "exec/3" do
     test "executes a command (binary) over a channel", %{chan: chan, impl: impl} do
-      impl |> expect(:exec, fn (connection_ref, channel_id, command, timeout) ->
+      impl
+      |> expect(:exec, fn connection_ref, channel_id, command, timeout ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
         assert command == 'cmd arg1 arg2'
@@ -77,7 +81,8 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "executes a command (charlist) over a channel", %{chan: chan, impl: impl} do
-      impl |> expect(:exec, fn (connection_ref, channel_id, command, timeout) ->
+      impl
+      |> expect(:exec, fn connection_ref, channel_id, command, timeout ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
         assert command == 'cmd arg1 arg2'
@@ -89,7 +94,8 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "executes a command with a specific timeout", %{chan: chan, impl: impl} do
-      impl |> expect(:exec, fn (_, _, _, timeout) ->
+      impl
+      |> expect(:exec, fn _, _, _, timeout ->
         assert timeout == 4000
         {:ok, 0}
       end)
@@ -98,12 +104,12 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "executes a failing command", %{chan: chan, impl: impl} do
-      impl |> expect(:exec, fn (_, _, _, _) -> :failure end)
+      impl |> expect(:exec, fn _, _, _, _ -> :failure end)
       assert exec(chan, "cmd") == :failure
     end
 
     test "returns an error if command cannot be executed", %{chan: chan, impl: impl} do
-      impl |> expect(:exec, fn (_, _, _, _) -> {:error, :closed} end)
+      impl |> expect(:exec, fn _, _, _, _ -> {:error, :closed} end)
       assert exec(chan, "cmd") == {:error, :closed}
     end
   end
@@ -141,19 +147,20 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "returns an error when channel not open", %{chan: chan, impl: impl} do
-      impl |> expect(:send, fn (_, _, _, _, _) -> {:error, :closed} end)
+      impl |> expect(:send, fn _, _, _, _, _ -> {:error, :closed} end)
       assert Channel.send(chan, "data") == {:error, :closed}
     end
 
     test "returns an error when channel times out", %{chan: chan, impl: impl} do
-      impl |> expect(:send, fn (_, _, _, _, _) -> {:error, :timeout} end)
+      impl |> expect(:send, fn _, _, _, _, _ -> {:error, :timeout} end)
       assert Channel.send(chan, "data") == {:error, :timeout}
     end
   end
 
   describe "eof/1" do
     test "sends EOF to open channel", %{chan: chan, impl: impl} do
-      impl |> expect(:send_eof, fn (connection_ref, channel_id) ->
+      impl
+      |> expect(:send_eof, fn connection_ref, channel_id ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
         :ok
@@ -163,7 +170,7 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "returns an error when channel not open", %{chan: chan, impl: impl} do
-      impl |> expect(:send_eof, fn (_, _) -> {:error, :closed} end)
+      impl |> expect(:send_eof, fn _, _ -> {:error, :closed} end)
       assert eof(chan) == {:error, :closed}
     end
   end
@@ -213,7 +220,8 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "adjusts the window size", %{chan: chan, impl: impl} do
-      impl |> expect(:adjust_window, fn (connection_ref, channel_id, size) ->
+      impl
+      |> expect(:adjust_window, fn connection_ref, channel_id, size ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
         assert size == 4096
@@ -226,13 +234,13 @@ defmodule SSHKit.SSH.ChannelTest do
 
   describe "loop/4" do
     test "loops over channel messages until channel is closed", %{conn: conn, chan: chan} do
-      Enum.each(0..2, &(Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}})))
+      Enum.each(0..2, &Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}}))
       Kernel.send(self(), {:ssh_cm, conn.ref, {:closed, chan.id}})
       assert Enum.count(messages(self())) == 4
 
       fun = fn
-        ({:msg, _, index}, _) -> {:cont, index}
-        ({:closed, _}, acc) -> {:cont, acc}
+        {:msg, _, index}, _ -> {:cont, index}
+        {:closed, _}, acc -> {:cont, acc}
       end
 
       assert loop(chan, 0, {:cont, -1}, fun) == {:done, 2}
@@ -241,19 +249,19 @@ defmodule SSHKit.SSH.ChannelTest do
 
     test "allows sending messages to the remote", %{conn: conn, chan: chan, impl: impl} do
       impl
-      |> expect(:send_eof, fn (_, _) -> :ok end)
+      |> expect(:send_eof, fn _, _ -> :ok end)
       |> expect(:send, sends(chan, 0, "plain", 200, :ok))
       |> expect(:send, sends(chan, 0, "normal", 200, :ok))
       |> expect(:send, sends(chan, 1, "error", 200, :ok))
 
-      Enum.each(0..4, &(Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}})))
+      Enum.each(0..4, &Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}}))
       Kernel.send(self(), {:ssh_cm, conn.ref, {:closed, chan.id}})
 
       msgs = [nil, :eof, "plain", {0, "normal"}, {1, "error"}]
 
       fun = fn
-        ({:msg, _, index}, _) -> {:cont, Enum.at(msgs, index), index}
-        ({:closed, _}, acc) -> {:cont, acc}
+        {:msg, _, index}, _ -> {:cont, Enum.at(msgs, index), index}
+        {:closed, _}, acc -> {:cont, acc}
       end
 
       assert loop(chan, 200, {:cont, -1}, fun) == {:done, 4}
@@ -261,13 +269,13 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "allows suspending the loop", %{conn: conn, chan: chan} do
-      Enum.each(0..1, &(Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}})))
+      Enum.each(0..1, &Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}}))
       Kernel.send(self(), {:ssh_cm, conn.ref, {:closed, chan.id}})
 
       fun = fn
-        ({:msg, _, _}, acc) when acc < 5 -> {:suspend, acc + 1}
-        ({:msg, _, _}, acc) -> {:cont, acc * 3}
-        ({:closed, _}, acc) -> {:cont, acc}
+        {:msg, _, _}, acc when acc < 5 -> {:suspend, acc + 1}
+        {:msg, _, _}, acc -> {:cont, acc * 3}
+        {:closed, _}, acc -> {:cont, acc}
       end
 
       {:suspended, 1, continue} = loop(chan, 0, {:cont, 0}, fun)
@@ -277,38 +285,39 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "allows halting the loop", %{conn: conn, chan: chan, impl: impl} do
-      impl |> expect(:close, fn (_, _) -> :ok end)
+      impl |> expect(:close, fn _, _ -> :ok end)
 
-      Enum.each(0..5, &(Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}})))
+      Enum.each(0..5, &Kernel.send(self(), {:ssh_cm, conn.ref, {:msg, chan.id, &1}}))
 
       fun = fn
-        (_, acc) when acc < 2 -> {:cont, acc + 1}
-        (_, acc) -> {:halt, acc}
+        _, acc when acc < 2 -> {:cont, acc + 1}
+        _, acc -> {:halt, acc}
       end
 
       assert loop(chan, 0, {:cont, 0}, fun) == {:halted, 2}
-      assert messages(self()) == [] # remaining messages flushed
+      # remaining messages flushed
+      assert messages(self()) == []
     end
 
     test "returns an error if next message is not received in time", %{chan: chan, impl: impl} do
-      impl |> expect(:close, fn (_, _) -> :ok end)
-      res = loop(chan, 0, {:cont, []}, &([&1 | &2]))
+      impl |> expect(:close, fn _, _ -> :ok end)
+      res = loop(chan, 0, {:cont, []}, &[&1 | &2])
       assert res == {:halted, {:error, :timeout}}
     end
 
     test "returns an error if message sending fails", %{chan: chan, impl: impl} do
       impl
       |> expect(:send, sends(chan, 0, "data", 100, {:error, :timeout}))
-      |> expect(:close, fn (_, _) -> :ok end)
+      |> expect(:close, fn _, _ -> :ok end)
 
-      res = loop(chan, 100, {:cont, "data", []}, &([&1 | &2]))
+      res = loop(chan, 100, {:cont, "data", []}, &[&1 | &2])
 
       assert res == {:halted, {:error, :timeout}}
     end
   end
 
   defp sends(chan, expected_type, expected_data, expected_timeout, res) do
-    fn (connection_ref, channel_id, type, data, timeout) ->
+    fn connection_ref, channel_id, type, data, timeout ->
       assert connection_ref == chan.connection.ref
       assert channel_id == chan.id
       assert type == expected_type

--- a/test/sshkit/ssh/connection_test.exs
+++ b/test/sshkit/ssh/connection_test.exs
@@ -8,13 +8,14 @@ defmodule SSHKit.SSH.ConnectionTest do
   alias SSHKit.SSH.Connection.ImplMock
 
   setup do
-    Mox.verify_on_exit!
+    Mox.verify_on_exit!()
     {:ok, impl: ImplMock}
   end
 
   describe "open/2" do
     test "opens a connection", %{impl: impl} do
-      impl |> expect(:connect, fn (host, port, opts, timeout) ->
+      impl
+      |> expect(:connect, fn host, port, opts, timeout ->
         assert host == 'test.io'
         assert port == 22
         assert opts == [user_interaction: false]
@@ -25,16 +26,17 @@ defmodule SSHKit.SSH.ConnectionTest do
       {:ok, conn} = open("test.io", impl: impl)
 
       assert conn == %Connection{
-        host:    'test.io',
-        port:    22,
-        options: [user_interaction: false],
-        ref:     :connection_ref,
-        impl:    impl
-      }
+               host: 'test.io',
+               port: 22,
+               options: [user_interaction: false],
+               ref: :connection_ref,
+               impl: impl
+             }
     end
 
     test "opens a connection on a different port with user and password", %{impl: impl} do
-      impl |> expect(:connect, fn (_, port, opts, _) ->
+      impl
+      |> expect(:connect, fn _, port, opts, _ ->
         assert port == 666
         assert opts[:user] == 'me'
         assert opts[:password] == 'secret'
@@ -45,16 +47,17 @@ defmodule SSHKit.SSH.ConnectionTest do
       {:ok, conn} = open("test.io", port: 666, user: "me", password: "secret", impl: impl)
 
       assert conn == %Connection{
-        host:    'test.io',
-        port:    666,
-        options: [user_interaction: false, user: 'me', password: 'secret'],
-        ref:     :ref_with_port_user_pass,
-        impl:    impl
-      }
+               host: 'test.io',
+               port: 666,
+               options: [user_interaction: false, user: 'me', password: 'secret'],
+               ref: :ref_with_port_user_pass,
+               impl: impl
+             }
     end
 
     test "opens a connection with user interaction option set to true", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, opts, _) ->
+      impl
+      |> expect(:connect, fn _, _, opts, _ ->
         assert opts[:user] == 'me'
         assert opts[:password] == 'secret'
         assert opts[:user_interaction] == true
@@ -66,16 +69,17 @@ defmodule SSHKit.SSH.ConnectionTest do
       {:ok, conn} = open("test.io", options)
 
       assert conn == %Connection{
-        host:    'test.io',
-        options: [user: 'me', password: 'secret', user_interaction: true],
-        port:    22,
-        ref:     :ref_with_user_interaction,
-        impl:    impl
-      }
+               host: 'test.io',
+               options: [user: 'me', password: 'secret', user_interaction: true],
+               port: 22,
+               ref: :ref_with_user_interaction,
+               impl: impl
+             }
     end
 
     test "opens a connection with a specific timeout", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, _, timeout) ->
+      impl
+      |> expect(:connect, fn _, _, _, timeout ->
         assert timeout == 3000
         {:ok, :ref}
       end)
@@ -84,7 +88,8 @@ defmodule SSHKit.SSH.ConnectionTest do
     end
 
     test "removes options irrelevant for connect/4", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, opts, _) ->
+      impl
+      |> expect(:connect, fn _, _, opts, _ ->
         option_keys = Keyword.keys(opts)
 
         refute :port in option_keys
@@ -100,7 +105,8 @@ defmodule SSHKit.SSH.ConnectionTest do
     end
 
     test "converts host to charlist", %{impl: impl} do
-      impl |> expect(:connect, fn (host, _, _, _) ->
+      impl
+      |> expect(:connect, fn host, _, _, _ ->
         assert host == 'test.io'
         {:ok, :ref}
       end)
@@ -109,7 +115,8 @@ defmodule SSHKit.SSH.ConnectionTest do
     end
 
     test "converts option values to charlists", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, opts, _) ->
+      impl
+      |> expect(:connect, fn _, _, opts, _ ->
         assert {:user, 'me'} in opts
         assert {:password, 'secret'} in opts
         {:ok, :ref}
@@ -119,7 +126,8 @@ defmodule SSHKit.SSH.ConnectionTest do
     end
 
     test "returns an error when connection cannot be opened", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, _, _) ->
+      impl
+      |> expect(:connect, fn _, _, _, _ ->
         {:error, :failed}
       end)
 
@@ -133,17 +141,18 @@ defmodule SSHKit.SSH.ConnectionTest do
 
   describe "close/1" do
     test "closes a connection", %{impl: impl} do
-      impl |> expect(:close, fn ref ->
+      impl
+      |> expect(:close, fn ref ->
         assert ref == :connection_ref
         :ok
       end)
 
       conn = %Connection{
-        host:    'foo.io',
-        port:    22,
+        host: 'foo.io',
+        port: 22,
         options: [user_interaction: false],
-        ref:     :connection_ref,
-        impl:    impl
+        ref: :connection_ref,
+        impl: impl
       }
 
       assert close(conn) == :ok
@@ -153,14 +162,15 @@ defmodule SSHKit.SSH.ConnectionTest do
   describe "reopen/2" do
     test "opens a new connection with the same options as the existing connection", %{impl: impl} do
       conn = %Connection{
-        host:    'test.io',
-        port:    22,
+        host: 'test.io',
+        port: 22,
         options: [user_interaction: false, user: 'me'],
-        ref:     :connection_ref,
-        impl:    impl
+        ref: :connection_ref,
+        impl: impl
       }
 
-      impl |> expect(:connect, fn (host, port, opts, _) ->
+      impl
+      |> expect(:connect, fn host, port, opts, _ ->
         assert host == conn.host
         assert port == conn.port
         assert opts == conn.options
@@ -174,14 +184,15 @@ defmodule SSHKit.SSH.ConnectionTest do
 
     test "reopens a connection on new port", %{impl: impl} do
       conn = %Connection{
-        host:    'test.io',
-        port:    22,
+        host: 'test.io',
+        port: 22,
         options: [user_interaction: false, user: 'me'],
-        ref:     :connection_ref,
-        impl:    impl
+        ref: :connection_ref,
+        impl: impl
       }
 
-      impl |> expect(:connect, fn (_, port, _, _) ->
+      impl
+      |> expect(:connect, fn _, port, _, _ ->
         assert port == 666
         {:ok, :new_connection_ref}
       end)
@@ -193,14 +204,15 @@ defmodule SSHKit.SSH.ConnectionTest do
 
     test "errors when unable to open connection", %{impl: impl} do
       conn = %Connection{
-        host:    'test.io',
-        port:    22,
+        host: 'test.io',
+        port: 22,
         options: [user_interaction: false],
-        ref:     :sandbox,
-        impl:    impl
+        ref: :sandbox,
+        impl: impl
       }
 
-      impl |> expect(:connect, fn (_, _, _, _) ->
+      impl
+      |> expect(:connect, fn _, _, _, _ ->
         {:error, :failed}
       end)
 

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -11,7 +11,7 @@ defmodule SSHKit.SSHTest do
   @user "me"
 
   setup do
-    Mox.verify_on_exit!
+    Mox.verify_on_exit!()
   end
 
   describe "connect/2" do
@@ -20,7 +20,8 @@ defmodule SSHKit.SSHTest do
     end
 
     test "opens a connection with the given options and keeps it open", %{impl: impl} do
-      impl |> expect(:connect, fn (host, port, opts, timeout) ->
+      impl
+      |> expect(:connect, fn host, port, opts, timeout ->
         assert host == 'test.io'
         assert port == 2222
         assert opts == [user_interaction: false, user: 'me']
@@ -31,16 +32,16 @@ defmodule SSHKit.SSHTest do
       {:ok, conn} = connect(@host, user: @user, port: 2222, impl: impl)
 
       assert conn == %Connection{
-        host:    'test.io',
-        options: [user_interaction: false, user: 'me'],
-        port:    2222,
-        ref:     :connection_ref,
-        impl:    impl
-      }
+               host: 'test.io',
+               options: [user_interaction: false, user: 'me'],
+               port: 2222,
+               ref: :connection_ref,
+               impl: impl
+             }
     end
 
     test "returns an error if connection cannot be opened", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, _, _) -> {:error, :timeout} end)
+      impl |> expect(:connect, fn _, _, _, _ -> {:error, :timeout} end)
       assert connect(@host, impl: impl) == {:error, :timeout}
     end
 
@@ -61,7 +62,7 @@ defmodule SSHKit.SSHTest do
 
     test "executes function on open connection", %{impl: impl} do
       impl
-      |> expect(:connect, fn (_, _, _, _) -> {:ok, :opened_connection_ref} end)
+      |> expect(:connect, fn _, _, _, _ -> {:ok, :opened_connection_ref} end)
       |> expect(:close, fn :opened_connection_ref -> :ok end)
 
       fun = fn conn ->
@@ -74,7 +75,7 @@ defmodule SSHKit.SSHTest do
 
     test "closes connection although function errored", %{impl: impl} do
       impl
-      |> expect(:connect, fn (_, _, _, _) -> {:ok, :opened_connection_ref} end)
+      |> expect(:connect, fn _, _, _, _ -> {:ok, :opened_connection_ref} end)
       |> expect(:close, fn :opened_connection_ref -> :ok end)
 
       fun = fn _ -> raise(RuntimeError, message: "error") end
@@ -85,8 +86,8 @@ defmodule SSHKit.SSHTest do
     end
 
     test "returns connection errors", %{impl: impl} do
-      impl |> expect(:connect, fn (_, _, _, _) -> {:error, :timeout} end)
-      fun = fn _ -> flunk "should never be called" end
+      impl |> expect(:connect, fn _, _, _, _ -> {:error, :timeout} end)
+      fun = fn _ -> flunk("should never be called") end
       assert connect(@host, [impl: impl], fun) == {:error, :timeout}
     end
   end
@@ -98,14 +99,15 @@ defmodule SSHKit.SSHTest do
 
     test "closes the connection", %{impl: impl} do
       conn = %SSHKit.SSH.Connection{
-        host:    'test.io',
-        port:    22,
+        host: 'test.io',
+        port: 22,
         options: [user_interaction: false],
-        ref:     :connection_ref,
-        impl:    impl
+        ref: :connection_ref,
+        impl: impl
       }
 
-      impl |> expect(:close, fn ref ->
+      impl
+      |> expect(:close, fn ref ->
         assert ref == conn.ref
         :ok
       end)
@@ -122,9 +124,9 @@ defmodule SSHKit.SSHTest do
 
     test "captures output and exit status by default", %{conn: conn, impl: impl} do
       impl
-      |> expect(:session_channel, fn (:cref, _, _, :infinity) -> {:ok, 11} end)
-      |> expect(:exec, fn (:cref, 11, 'try', :infinity) -> :success end)
-      |> expect(:adjust_window, 2, fn (:cref, 11, _) -> :ok end)
+      |> expect(:session_channel, fn :cref, _, _, :infinity -> {:ok, 11} end)
+      |> expect(:exec, fn :cref, 11, 'try', :infinity -> :success end)
+      |> expect(:adjust_window, 2, fn :cref, 11, _ -> :ok end)
 
       send(self(), {:ssh_cm, conn.ref, {:data, 11, 0, "out"}})
       send(self(), {:ssh_cm, conn.ref, {:data, 11, 1, "err"}})
@@ -136,17 +138,17 @@ defmodule SSHKit.SSHTest do
 
     test "accepts a custom handler function and accumulator", %{conn: conn, impl: impl} do
       impl
-      |> expect(:session_channel, fn (:cref, _, _, _) -> {:ok, 31} end)
-      |> expect(:exec, fn (:cref, 31, 'cmd', _) -> :success end)
-      |> expect(:send, fn (:cref, 31, 0, "PING", _) -> :ok end)
-      |> expect(:adjust_window, fn (:cref, 31, _) -> :ok end)
-      |> expect(:close, fn (:cref, 31) -> :ok end)
+      |> expect(:session_channel, fn :cref, _, _, _ -> {:ok, 31} end)
+      |> expect(:exec, fn :cref, 31, 'cmd', _ -> :success end)
+      |> expect(:send, fn :cref, 31, 0, "PING", _ -> :ok end)
+      |> expect(:adjust_window, fn :cref, 31, _ -> :ok end)
+      |> expect(:close, fn :cref, 31 -> :ok end)
 
       send(self(), {:ssh_cm, conn.ref, {:data, 31, 0, "PONG"}})
 
       ini = {:cont, "PING", ["START"]}
 
-      fun = fn (msg, acc) ->
+      fun = fn msg, acc ->
         case msg do
           {:data, _, 0, data} -> {:halt, [data | acc]}
           _ -> {:cont, "NOPE", ["FAILED" | acc]}
@@ -158,10 +160,10 @@ defmodule SSHKit.SSHTest do
 
     test "accepts a timeout value", %{conn: conn, impl: impl} do
       impl
-      |> expect(:session_channel, fn (_, _, _, 500) -> {:ok, 61} end)
-      |> expect(:exec, fn (_, _, _, 500) -> :success end)
-      |> expect(:send, fn (_, _, _, _, 500) -> {:error, :timeout} end)
-      |> expect(:close, fn (_, _) -> :ok end)
+      |> expect(:session_channel, fn _, _, _, 500 -> {:ok, 61} end)
+      |> expect(:exec, fn _, _, _, 500 -> :success end)
+      |> expect(:send, fn _, _, _, _, 500 -> {:error, :timeout} end)
+      |> expect(:close, fn _, _ -> :ok end)
 
       acc = {:cont, "INIT", {[], nil}}
 
@@ -169,14 +171,14 @@ defmodule SSHKit.SSHTest do
     end
 
     test "returns an error if channel cannot be opened", %{conn: conn, impl: impl} do
-      impl |> expect(:session_channel, fn (_, _, _, _) -> {:error, :timeout} end)
+      impl |> expect(:session_channel, fn _, _, _, _ -> {:error, :timeout} end)
       assert run(conn, "uptime", impl: impl) == {:error, :timeout}
     end
 
     test "returns an error if command fails to execute", %{conn: conn, impl: impl} do
       impl
-      |> expect(:session_channel, fn (_, _, _, _) -> {:ok, 13} end)
-      |> expect(:exec, fn (_, _, _, _) -> :failure end)
+      |> expect(:session_channel, fn _, _, _, _ -> {:ok, 13} end)
+      |> expect(:exec, fn _, _, _, _ -> :failure end)
 
       assert run(conn, "uptime", impl: impl) == {:error, :failure}
     end

--- a/test/sshkit/utils_test.exs
+++ b/test/sshkit/utils_test.exs
@@ -17,18 +17,18 @@ defmodule SSHKit.UtilsTest do
     end
 
     test "converts binaries in keywords" do
-      assert Utils.charlistify([inet: :inet6, user: "me"]) == [inet: :inet6, user: 'me']
+      assert Utils.charlistify(inet: :inet6, user: "me") == [inet: :inet6, user: 'me']
     end
 
     test "converts binaries in nested lists" do
-      actual = Utils.charlistify([pref_public_key_algs: ["ssh-rsa", "ssh-dss"]])
+      actual = Utils.charlistify(pref_public_key_algs: ["ssh-rsa", "ssh-dss"])
       expected = [pref_public_key_algs: ['ssh-rsa', 'ssh-dss']]
       assert actual == expected
     end
 
     test "converts binaries in nested keywords" do
       ciphers = [client2server: ["aes128-ctr"], server2client: ["aes128-cbc", "3des-cbc"]]
-      actual = Utils.charlistify([preferred_algorithms: [cipher: ciphers]])
+      actual = Utils.charlistify(preferred_algorithms: [cipher: ciphers])
       expected = [preferred_algorithms: [cipher: Utils.charlistify(ciphers)]]
       assert actual == expected
     end

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -173,7 +173,7 @@ defmodule SSHKitFunctionalTest do
       tmpdir = create_local_tmp_path()
 
       :ok = File.mkdir!(tmpdir)
-      on_exit fn -> File.rm_rf(tmpdir) end
+      on_exit(fn -> File.rm_rf(tmpdir) end)
 
       {:ok, tmpdir: tmpdir}
     end

--- a/test/support/functional_assertion_helpers.ex
+++ b/test/support/functional_assertion_helpers.ex
@@ -6,47 +6,57 @@ defmodule SSHKit.FunctionalAssertionHelpers do
 
   def verify_transfer(conn, local, remote) do
     command = &"find #{&1} -type f -exec #{&2} {} \\; | sort | awk '{print $1}' | xargs"
-    compare_command_output(conn,
+
+    compare_command_output(
+      conn,
       command.(local, SystemCommands.shasum_cmd()),
       command.(remote, "sha1sum")
-      )
+    )
   end
 
   def verify_mode(conn, local, remote) do
     command = &"find #{&1} -type f -exec ls -l {} + | awk '{print $1 $5}' | sort |xargs"
-    compare_command_output(conn,
+
+    compare_command_output(
+      conn,
       command.(local),
       command.(remote)
-      )
+    )
   end
 
   def verify_atime(conn, local, remote) do
     command = &"env find #{&1} -type f -exec #{&2} {} \\; | cut -f1,2 | sort | xargs"
-      compare_command_output(conn,
-        command.(local, SystemCommands.stat_cmd()),
-        command.(remote, "stat -c '%s\t%X\t%Y'")
-      )
+
+    compare_command_output(
+      conn,
+      command.(local, SystemCommands.stat_cmd()),
+      command.(remote, "stat -c '%s\t%X\t%Y'")
+    )
   end
 
   def verify_mtime(conn, local, remote) do
     command = &"env find #{&1} -type f -exec #{&2} {} \\; | cut -f1,3 | sort | xargs"
-    compare_command_output(conn,
+
+    compare_command_output(
+      conn,
       command.(local, SystemCommands.stat_cmd()),
       command.(remote, "stat -c '%s\t%X\t%Y'")
-      )
+    )
   end
 
   def compare_command_output(context = %Context{}, local, remote) do
-    Enum.map(context.hosts,
-      fn(h) ->
-        SSH.connect h.name, h.options, fn(conn) ->
+    Enum.map(
+      context.hosts,
+      fn h ->
+        SSH.connect(h.name, h.options, fn conn ->
           compare_command_output(conn, local, remote)
-        end
-      end)
+        end)
+      end
+    )
   end
 
   def compare_command_output(conn, local, remote) do
-    local_output = local |> String.to_charlist |> :os.cmd |> to_string
+    local_output = local |> String.to_charlist() |> :os.cmd() |> to_string
     {:ok, [stdout: remote_output], 0} = SSH.run(conn, remote)
     assert local_output == remote_output
   end

--- a/test/support/functional_case.ex
+++ b/test/support/functional_case.ex
@@ -64,7 +64,7 @@ defmodule SSHKit.FunctionalCase do
   end
 
   def kill!(hosts) do
-    running = Enum.map(hosts, &(Map.get(&1, :id)))
+    running = Enum.map(hosts, &Map.get(&1, :id))
     killed = Docker.kill!(running)
     diff = running -- killed
     if Enum.empty?(diff), do: :ok, else: {:error, diff}

--- a/test/support/functional_case_helpers.ex
+++ b/test/support/functional_case_helpers.ex
@@ -19,7 +19,14 @@ defmodule SSHKit.FunctionalCaseHelpers do
   end
 
   def keygen!(_host = %{id: id}, username) do
-    Docker.exec!([], id, "sh", ["-c", "ssh-keygen -b 1024 -f /tmp/#{username} -N '' -C \"#{username}@$(hostname)\""])
-    Docker.exec!([], id, "sh", ["-c", "cat /tmp/#{username}.pub > /home/#{username}/.ssh/authorized_keys"])
+    Docker.exec!([], id, "sh", [
+      "-c",
+      "ssh-keygen -b 1024 -f /tmp/#{username} -N '' -C \"#{username}@$(hostname)\""
+    ])
+
+    Docker.exec!([], id, "sh", [
+      "-c",
+      "cat /tmp/#{username}.pub > /home/#{username}/.ssh/authorized_keys"
+    ])
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -15,10 +15,13 @@ defmodule SSHKit.SSH.Channel.Impl do
   @type conn :: any()
   @type chan :: integer()
 
-  @callback session_channel(conn, integer(), integer(), timeout()) :: {:ok, chan} | {:error, any()}
+  @callback session_channel(conn, integer(), integer(), timeout()) ::
+              {:ok, chan} | {:error, any()}
   @callback close(conn, chan) :: :ok
-  @callback exec(conn, chan, binary(), timeout()) :: :success | :failure | {:error, :timeout} | {:error, :closed}
-  @callback send(conn, chan, 0..1, binary(), timeout()) :: :ok | {:error, :timeout} | {:error, :closed}
+  @callback exec(conn, chan, binary(), timeout()) ::
+              :success | :failure | {:error, :timeout} | {:error, :closed}
+  @callback send(conn, chan, 0..1, binary(), timeout()) ::
+              :ok | {:error, :timeout} | {:error, :closed}
   @callback send_eof(conn, chan) :: :ok | {:error, :closed}
   @callback adjust_window(conn, chan, integer()) :: :ok
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,9 +1,9 @@
 excluded = Application.get_env(:ex_unit, :exclude)
 included = Application.get_env(:ex_unit, :include)
 
-unless (:functional in excluded) && !(:functional in included) do
-  unless Docker.ready? do
-    IO.puts """
+unless :functional in excluded && !(:functional in included) do
+  unless Docker.ready?() do
+    IO.puts("""
     It seems like Docker isn't running?
 
     Please check:
@@ -11,7 +11,7 @@ unless (:functional in excluded) && !(:functional in included) do
     1. Docker is installed: `docker version`
     2. On OS X and Windows: `docker-machine start`
     3. Environment is set up: `eval $(docker-machine env)`
-    """
+    """)
 
     exit({:shutdown, 1})
   end
@@ -20,16 +20,18 @@ unless (:functional in excluded) && !(:functional in included) do
 end
 
 shasum_command = SystemCommands.shasum_cmd()
+
 try do
   System.cmd(shasum_command, ["--version"])
 rescue
   error in ErlangError ->
-    IO.puts """
+    IO.puts("""
     An error happened while executing #{shasum_command} (#{error.original}).
 
     It seems like the `#{shasum_command}` command isn't available?
     Please check that #{shasum_command} is installed: `which #{shasum_command}`
-    """
+    """)
+
     exit({:shutdown, 1})
 end
 


### PR DESCRIPTION
Use mix format for consistently formatting source code and check for
formatting issues on CI.

-- https://hexdocs.pm/mix/1.6/Mix.Tasks.Format.html

This PR probably needs to be updated once our other open PRs are merged.