### PR TITLE
[#62] SCP upload with `recursive: true` should notify user of an erro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Thanks for your contributions:
 * Fix error handling in `SSHKit.SSH.Channel.send/4` when sending stream data
 * Context properly handles the case where env is set to an empty map
 * Fix environment variables export in contexts with user, group, umask, path and env
+* Fix SCP upload not making any progress after receiving a warning [#62]
 
 ## `0.0.3` (2017-07-13)
 

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -134,7 +134,7 @@ defmodule SSHKit.SCP.Upload do
     stat = File.stat!(path, time: :posix)
 
     stack = case stat.type do
-      :directory -> [File.ls!(path) | [rest | dirs]]
+      :directory -> [Enum.sort(File.ls!(path)) | [rest | dirs]]
       :regular -> [rest | dirs]
     end
 

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -192,9 +192,9 @@ defmodule SSHKit.SCP.Upload do
     {:cont, {:error, "SCP channel closed before completing the transfer"}}
   end
 
-  defp warning(_, state = {name, cwd, stack, errs}, buffer) do
+  defp warning(options, state = {name, cwd, [[_ | rest] | dirs], errs}, buffer) do
     if String.last(buffer) == "\n" do
-      {:cont, {name, cwd, stack, errs ++ [String.trim(buffer)]}}
+      next(options, cwd, [rest | dirs], errs ++ [String.trim(buffer)])
     else
       {:cont, {:warning, state, buffer}}
     end

--- a/test/sshkit/scp/upload_test.exs
+++ b/test/sshkit/scp/upload_test.exs
@@ -5,14 +5,14 @@ defmodule SSHKit.SCP.UploadTest do
   alias SSHKit.SCP.Upload
   alias SSHKit.SSHMock
 
-  @local "test/fixtures/local_dir"
+  @local "test/fixtures"
+  @abslocal @local |> Path.expand()
   @remote "/home/test/code"
 
   describe "new/3" do
     test "returns a new upload struct" do
       upload = Upload.new(@local, @remote)
-      local_expanded = @local |> Path.expand()
-      assert %Upload{local: ^local_expanded, remote: @remote} = upload
+      assert %Upload{local: @abslocal, remote: @remote} = upload
     end
 
     test "returns a new upload struct with options" do
@@ -23,8 +23,8 @@ defmodule SSHKit.SCP.UploadTest do
 
     test "upload struct has initial state" do
       %Upload{state: state} = Upload.new(@local, @remote)
-      current_directory = @local |> Path.expand() |> Path.dirname()
-      assert state == {:next, current_directory, [["local_dir"]], []}
+      base_directory = @abslocal |> Path.dirname()
+      assert state == {:next, base_directory, [["fixtures"]], []}
     end
 
     test "upload struct has a handler function" do
@@ -76,38 +76,35 @@ defmodule SSHKit.SCP.UploadTest do
     end
 
     test "recurses into directories", %{upload: upload, ack: ack} do
-      %Upload{handler: handler, state: {:next, cwd, [["local_dir"]], []} = state} = upload
-      next_path = Path.join(cwd, "local_dir")
+      %Upload{handler: handler, state: {:next, cwd, [["fixtures"]], []} = state} = upload
+      next_path = Path.join(cwd, "fixtures")
 
-      assert {:cont, 'D0755 0 local_dir\n', {:next, ^next_path, [["other.txt"], []], []}} = handler.(ack, state)
+      assert {:cont, 'D0755 0 fixtures\n', {:next, ^next_path, [["local.txt", "local_dir"], []], []}} = handler.(ack, state)
     end
 
     test "create files in the current directory", %{upload: %Upload{handler: handler}, ack: ack} do
-      local_expanded = @local |> Path.expand()
-      state = {:next, local_expanded, [["other.txt"], []], []}
-      assert {:cont, 'C0644 61 other.txt\n', {:write, "other.txt", %File.Stat{}, ^local_expanded, [[], []], []}} = handler.(ack, state)
+      state = {:next, @abslocal, [["local.txt", "local_dir"], []], []}
+      assert {:cont, 'C0644 51 local.txt\n', {:write, "local.txt", %File.Stat{}, @abslocal, [["local_dir"], []], []}} = handler.(ack, state)
     end
 
     test "writes files in the current directory", %{upload: %Upload{handler: handler}, ack: ack} do
-      local_expanded = @local |> Path.expand() |> Path.join("local_dir")
-      state = {:write, "other.txt", %File.Stat{}, local_expanded, [[], []], []}
-      fs = File.stream!(Path.join(local_expanded, "other.txt"), [], 16_384)
-      write_state = {:cont, Stream.concat(fs, [<<0>>]), {:next, local_expanded, [[], []], []}}
+      cwd = @abslocal |> Path.join("local_dir")
+      state = {:write, "other.txt", %File.Stat{}, cwd, [[], []], []}
+      fs = File.stream!(Path.join(cwd, "other.txt"), [], 16_384)
+      write_state = {:cont, Stream.concat(fs, [<<0>>]), {:next, cwd, [[], []], []}}
 
       assert write_state == handler.(ack, state)
     end
 
     test "moves upwards in the directory hierachy", %{upload: %Upload{handler: handler}, ack: ack} do
-      local_dir = @local |> Path.expand() |> Path.join("local_dir")
-      local_expanded = @local |> Path.expand()
-      state = {:next, local_dir, [[], []], []}
+      cwd = @abslocal |> Path.join("local_dir")
+      state = {:next, cwd, [[], []], []}
 
-      assert {:cont, 'E\n', {:next, ^local_expanded, [[]], []}} = handler.(ack, state)
+      assert {:cont, 'E\n', {:next, @abslocal, [[]], []}} = handler.(ack, state)
     end
 
     test "finalizes the upload", %{upload: %Upload{handler: handler}, ack: ack, channel: channel} do
-      local_expanded = @local |> Path.expand()
-      state = {:next, local_expanded, [[]], []}
+      state = {:next, @abslocal, [[]], []}
 
       assert {:cont, :eof, done_state} = handler.(ack, state)
       assert done_state == {:done, nil, []}
@@ -124,20 +121,20 @@ defmodule SSHKit.SCP.UploadTest do
       assert {:cont, :ok} == handler.(closed_msg, eof_state)
     end
 
-    test "aggregates warnings in the state", %{upload: %Upload{handler: handler, state: state}, channel: channel} do
-      error_msg = "error part 1 error part 2 error part 3"
-      {name, cwd, stack, _errs} = state
+    test "aggregates warnings in the state and skips to the next file", %{upload: %Upload{handler: handler}, channel: channel} do
+      warning = "scp: /some/nonexistent/destination: No such file or directory"
+      state = {:next, @abslocal, [["local.txt", "local_dir"], []], []}
 
-      msg1 = {:data, channel, 0, <<1, "error part 1 ">>}
-      state1 = {:warning, state, "error part 1 "}
+      msg1 = {:data, channel, 0, <<1, "scp: ">>}
+      state1 = {:warning, state, "scp: "}
       assert {:cont, state1} == handler.(msg1, state)
 
-      msg2 = {:data, channel, 0, <<"error part 2 ">>}
-      state2 = {:warning, state, "error part 1 error part 2 "}
+      msg2 = {:data, channel, 0, <<"/some/nonexistent/destination: ">>}
+      state2 = {:warning, state, "scp: /some/nonexistent/destination: "}
       assert {:cont, state2} == handler.(msg2, state1)
 
-      msg3 = {:data, channel, 0, <<"error part 3\n">>}
-      assert {:cont, {name, cwd, stack, [error_msg]}} == handler.(msg3, state2)
+      msg3 = {:data, channel, 0, <<"No such file or directory\n">>}
+      assert {:cont, 'D0755 0 local_dir\n', {:next, Path.join(@abslocal, "local_dir"), [["other.txt"], [], []], [warning]}} == handler.(msg3, state2)
     end
 
     test "aggregates connection errors in the state and halts", %{upload: %Upload{handler: handler, state: state}, channel: channel} do

--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -52,6 +52,17 @@ defmodule SSHKit.SCPFunctionalTest do
         assert verify_mtime(conn, local, remote)
       end
     end
+
+    @tag boot: [@bootconf], focus: true
+    test "uploads to nonexistent target directory (recursive: true)", %{hosts: [host]} do
+      local = "test/fixtures/local_dir"
+      remote = "/some/nonexistent/destination"
+
+      SSH.connect host.name, host.options, fn conn ->
+        assert {:error, msg} = SCP.upload(conn, local, remote, recursive: true)
+        assert msg =~ "scp: /some/nonexistent/destination: No such file or directory"
+      end
+    end
   end
 
   describe "download/4" do


### PR DESCRIPTION
…r when the destination directory does not exist

### Description

<!--- Please describe what you did. -->

### Motivation and Context

> I just observed that when attempting to SCP upload a directory with recursive: true, SSHKit does not notify the user of an error if the target destination directory does not exist. Instead SSHKit appears to hang until a timeout happens.

— see https://github.com/bitcrowd/sshkit.ex/issues/62

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
