### PR TITLE
PTTY allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.1.0...HEAD
 
 ### New features:
 
+* Added support for ptty allocation in channel module [#129]
 * Put new features here
 
 ### Fixes:

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -77,6 +77,17 @@ defmodule SSHKit.SSH.Channel do
   end
 
   @doc """
+  Allocates PTTY.
+
+  Returns `:success`.
+
+  For more details, see [`:ssh_connection.ptty_alloc/4`](http://erlang.org/doc/man/ssh_connection.html#ptty_alloc-4).
+  """
+  def ptty(channel, options \\ [], timeout \\ :infinity) do
+    channel.impl.ptty_alloc(channel.connection.ref, channel.id, options, timeout)
+  end
+
+  @doc """
   Sends data across an open SSH channel.
 
   `data` may be an enumerable, e.g. a `File.Stream` or `IO.Stream`.

--- a/test/sshkit/ssh/channel_test.exs
+++ b/test/sshkit/ssh/channel_test.exs
@@ -108,6 +108,20 @@ defmodule SSHKit.SSH.ChannelTest do
     end
   end
 
+  describe "ptty/4" do
+    test "allocates ptty", %{chan: chan, impl: impl} do
+      impl |> expect(:ptty_alloc, fn (connection_ref, channel_id, options, timeout) ->
+        assert connection_ref == chan.connection.ref
+        assert channel_id == chan.id
+        assert options == []
+        assert timeout == :infinity
+        :success
+      end)
+
+      assert ptty(chan) == :success
+    end
+  end
+
   describe "send/4" do
     test "send binary data across channel", %{chan: chan, impl: impl} do
       impl |> expect(:send, sends(chan, 0, "binary data", :infinity, :ok))

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -18,6 +18,7 @@ defmodule SSHKit.SSH.Channel.Impl do
   @callback session_channel(conn, integer(), integer(), timeout()) :: {:ok, chan} | {:error, any()}
   @callback close(conn, chan) :: :ok
   @callback exec(conn, chan, binary(), timeout()) :: :success | :failure | {:error, :timeout} | {:error, :closed}
+  @callback ptty_alloc(conn, chan, keyword(), timeout()) :: :success | :failure | {:error, :timeout} | {:error, :closed}
   @callback send(conn, chan, 0..1, binary(), timeout()) :: :ok | {:error, :timeout} | {:error, :closed}
   @callback send_eof(conn, chan) :: :ok | {:error, :closed}
   @callback adjust_window(conn, chan, integer()) :: :ok


### PR DESCRIPTION
Added ptty allocation method for channel

### Description

Implementation of http://erlang.org/doc/man/ssh_connection.html#ptty_alloc-4

### Motivation and Context

Some network devices have ssh server which doesn't provide ptty automatically, and we need to request this manually.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes (with unit and/or functional tests).
- [X] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
