### PR TITLE
[#40] Allow SSHKit.run executing on hosts in parallel

### DIFF
--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -330,7 +330,7 @@ defmodule SSHKit do
     |> Enum.map(fn host -> Task.async(fn -> op.(host) end) end)
     |> Enum.map(fn task -> Task.await(task, :infinity) end)
   end
-  
+
   @doc ~S"""
   Upload a file or files to the given context.
 

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -308,12 +308,12 @@ defmodule SSHKit do
   assert "Hello World!\n" == stdout
   ```
   """
-  def run(context, command, mode \\ :sequential) do
+  def run(context, command, mode \\ :sequential, timeout \\ :infinity) do
     cmd = Context.build(context, command)
 
     op = fn host ->
       {:ok, conn} = SSH.connect(host.name, host.options)
-      res = SSH.run(conn, cmd)
+      res = SSH.run(conn, cmd, [timeout: timeout])
       :ok = SSH.close(conn)
       res
     end
@@ -328,7 +328,7 @@ defmodule SSHKit do
   defp perform(hosts, op, :parallel) do
     hosts
     |> Enum.map(fn host -> Task.async(fn -> op.(host) end) end)
-    |> Enum.map(fn task -> Task.await(task) end)
+    |> Enum.map(fn task -> Task.await(task, :infinity) end)
   end
   
   @doc ~S"""

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -308,34 +308,29 @@ defmodule SSHKit do
   assert "Hello World!\n" == stdout
   ```
   """
-  def run(context, command) do
+  def run(context, command, mode \\ :sequential) do
     cmd = Context.build(context, command)
 
-    run = fn host ->
+    op = fn host ->
       {:ok, conn} = SSH.connect(host.name, host.options)
       res = SSH.run(conn, cmd)
       :ok = SSH.close(conn)
       res
     end
 
-    Enum.map(context.hosts, run)
+    perform(context.hosts, op, mode)
   end
 
-  def run(context, command, timeout \\ 10000, mode: :parallel) do
-    cmd = Context.build(context, command)
-
-    run = fn host ->
-      {:ok, conn} = SSH.connect(host.name, host.options)
-      res = SSH.run(conn, cmd)
-      :ok = SSH.close(conn)
-      res
-    end
-
-    Enum.map(context.hosts, fn h -> Task.async(fn -> run.(h) end) end)
-    |> Enum.map(fn n -> Task.await(n,timeout) end)
-    
+  defp perform(hosts, op, :sequential) do
+    Enum.map(hosts, op)
   end
 
+  defp perform(hosts, op, :parallel) do
+    hosts
+    |> Enum.map(fn host -> Task.async(fn -> op.(host) end) end)
+    |> Enum.map(fn task -> Task.await(task) end)
+  end
+  
   @doc ~S"""
   Upload a file or files to the given context.
 

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -18,6 +18,23 @@ defmodule SSHKitFunctionalTest do
     end
 
     @tag boot: [@bootconf]
+    test "connects as the login user and runs commands in parallel", %{hosts: [host]} do
+      begin_time = Time.utc_now()
+      [{:ok, output1, 0},{:ok, output2, 0},{:ok, output3, 0}] =
+        [host, host, host]
+        |> SSHKit.context()
+        |> SSHKit.run("sleep 2; id -un", :parallel)
+      end_time = Time.utc_now()
+      run_time = Time.diff(end_time, begin_time, :second)
+
+      assert run_time < 3
+      assert String.trim(stdout(output1)) == host.options[:user]
+      assert String.trim(stdout(output2)) == host.options[:user]
+      assert String.trim(stdout(output3)) == host.options[:user]
+
+    end
+    
+    @tag boot: [@bootconf]
     test "runs commands and returns their output and exit status", %{hosts: [host]} do
       context = SSHKit.context(host)
 

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -20,17 +20,16 @@ defmodule SSHKitFunctionalTest do
     @tag boot: [@bootconf]
     test "connects as the login user and runs commands in parallel", %{hosts: [host]} do
       begin_time = Time.utc_now()
-      [{:ok, output1, 0},{:ok, output2, 0},{:ok, output3, 0}] =
-        [host, host, host]
+      [{:ok, output1, 0},{:ok, output2, 0}] =
+        [host, host]
         |> SSHKit.context()
         |> SSHKit.run("sleep 2; id -un", :parallel)
       end_time = Time.utc_now()
       run_time = Time.diff(end_time, begin_time, :second)
 
-      assert run_time < 3
+      assert run_time < 4
       assert String.trim(stdout(output1)) == host.options[:user]
       assert String.trim(stdout(output2)) == host.options[:user]
-      assert String.trim(stdout(output3)) == host.options[:user]
 
     end
     


### PR DESCRIPTION
Allow SSHKit.run executing on hosts in parallel
### Description

SSHKit.run can do its job in sequential and parallel.
SSHKit.run(context, cmd, :sequential, 1000) runs cmd sequentially with its timeout 1000ms.
SSHKit.run(context, cmd, :parallel, 1000) runs cmd sequentially with its each cmd's timeout 1000ms.

### Motivation and Context
Please refer to https://github.com/bitcrowd/sshkit.ex/issues/40

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
