### PR TITLE
Expose `:ssh_connection.subsystem/4`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.2...v0.0.3
 * Improved documentation [#67]
 * Added support for passing an anonymous function to `SSH.connect` [#72]
 * Add support for passing a `dry_run` flag to `SSHKit.SSH.connect` [#79]
+* Add support for `:ssh_connection.subsystem/4`
 
 ### Fixes:
 

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -39,6 +39,15 @@ defmodule SSHKit.SSH.Channel do
     end
   end
 
+  @doc """
+  Activates a subsystem on a channel.
+
+  On success, returns `:ok`. On failure, returns `{:error, reason}`.
+
+  For more details, see [`:ssh_connection.subsystem/4`](http://erlang.org/doc/man/ssh_connection.html#subsystem-4).
+  """
+  @spec subsystem(channel :: struct(), subsystem :: String.t(), options :: list()) ::
+          :ok | {:error, reason :: String.t()}
   def subsystem(channel, subsystem, options \\ []) do
     timeout = Keyword.get(options, :timeout, :infinity)
     impl = Keyword.get(options, :impl, :ssh_connection)

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -39,6 +39,22 @@ defmodule SSHKit.SSH.Channel do
     end
   end
 
+  def subsystem(channel, subsystem, options \\ []) do
+    timeout = Keyword.get(options, :timeout, :infinity)
+    impl = Keyword.get(options, :impl, :ssh_connection)
+
+    case impl.subsystem(channel.connection.ref, channel.id, to_charlist(subsystem), timeout) do
+      :success ->
+        :ok
+
+      :failure ->
+        {:error, :failure}
+
+      err ->
+        err
+    end
+  end
+
   defp build(connection, id, impl) do
     %Channel{connection: connection, type: :session, id: id, impl: impl}
   end


### PR DESCRIPTION
### Description

Exposes `:ssh_connection.subsystem/4` in SSHKit.

### Motivation and Context

We are writing a netconf driver, and activating the netconf subsystem is required.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
