### PR TITLE
RFC: Update API to enable connection re-use, allow streaming…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,19 @@ repeatable way, e.g. in the context of deployment tools:
 hosts = ["1.eg.io", {"2.eg.io", port: 2222}]
 
 context =
-  SSHKit.context(hosts)
+  SSHKit.context()
   |> SSHKit.path("/var/www/phx")
   |> SSHKit.user("deploy")
   |> SSHKit.group("deploy")
   |> SSHKit.umask("022")
   |> SSHKit.env(%{"NODE_ENV" => "production"})
 
-:ok = SSHKit.upload(context, ".", recursive: true)
-:ok = SSHKit.run(context, "yarn install")
+{:ok, conn} = SSHKit.connect(hosts)
+
+{:ok, conn} = SSHKit.upload(conn, context, ".", recursive: true)
+{:ok, conn} = SSHKit.run(conn, context, "yarn install")
+
+{:ok, _} = SSHKit.close(conn)
 ```
 
 The [`SSHKit`](https://hexdocs.pm/sshkit/SSHKit.html) module documentation has


### PR DESCRIPTION
Related to: https://github.com/bitcrowd/sshkit.ex/issues/41

### Description

Update the top-level SSHKit API in order to reuse SSH connections across SSHKit operations, i.e. `SSHKit.run/3`, `SSHKit.upload/4` and `SSHKit.download/4`.

The updated API could look as follows (feedback welcome):

```elixir
hosts = ["1.eg.io", {"2.eg.io", port: 2222}]

# UPDATED: The context no longer receives a list of hosts/a single host.
# It exclusively manages the execution context on the remotes.
context =
  SSHKit.context()
  |> SSHKit.path("/var/www/phx")
  |> SSHKit.user("deploy")
  |> SSHKit.group("deploy")
  |> SSHKit.umask("022")
  |> SSHKit.env(%{"NODE_ENV" => "production"})

# NEW: Explicitly establish a connection
{:ok, conn} = SSHKit.connect(hosts)

# UPDATED: The top-level functions now require a conn struct.
{:ok, conn} = SSHKit.upload(conn, context, ".", recursive: true)
{:ok, conn} = SSHKit.run(conn, context, "yarn install")

# IDEA: Passing a context could be optional (different possible versions)
{:ok, conn} = SSHKit.run(conn, "apt-get install -y postgresql", context: context)
{:ok, conn} = conn |> SSHKit.within(context) |> SSHKit.run(conn, "apt-get install -y postgresql")

# NEW: Explicitly close the connection once we're done
{:ok, _} = SSHKit.close(conn)
```

cf. current [README.md](https://github.com/bitcrowd/sshkit.ex/blob/master/README.md#usage)

**Additional considerations**

A major idea/API change that may play into this draft is how we handle stdout/stderr streaming which is an interesting case we did not handle in SSHKit 0.x but is definitely interesting to give quicker user feedback, e.g. on deployment cases as with bootleg (see the [alt. `capture` implementation](https://github.com/labzero/bootleg/blob/5dcbd483c4099359387d2e9a8cb7e93a923422c2/lib/bootleg/ssh.ex#L195-L222)).

This might solve/play into #53 as well.

**Make context optional?**

With the API update, context could be made an optional or keyword argument, because for some things you want to run, you might not need any user/group/path/env/umask changes.

**Update host struct**

There was a request to include host information in result tuples #132 and Bootleg defines a `%Host{}` struct to assign a `name`, we should consider adding  `name` and possibly `tags` to hosts.

### Motivation and Context

At the moment, SSHKit is establishing a new connection for every command. The outlined API changes could allow us to reuse established connections for multiple consecutive operations and improve the speed with which server automation tasks can be carried out. Deployments with [bootleg](https://github.com/labzero/bootleg) (cc @labzero) for instance could benefit from this.

### Discussion: Alternative Designs

As #41 outlines, we could also use a (GenServer) process to cache connections. This however means that it would be harder/not possible to - for instance - open multiple connections to the same server.

It also seems more explicit and conceptually cleaner to separate execution context (`SSHKit.context/0`) from connection information (the new `conn` struct).

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
