### PR TITLE
[#121] Context-aware SSHKit uploads & downloads (A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.1.0...HEAD
 
 * Put high-level summary here
 
+* The `SSHKit.download/3` and `SSHKit.upload/3` functions are now fully context-aware
+* They will respect the `user`, `env`, `path`… values set in the context
+
 ### Deprecations:
 
 * Put deprecations here
@@ -15,6 +18,8 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.1.0...HEAD
 ### Potentially breaking changes:
 
 * Put potentially breaking changes here
+
+* The interfaces for the `SSHKit.SCP` and `SSHKit.SCP.{Download, Upload}` modules have changed
 
 ### New features:
 

--- a/lib/sshkit/scp.ex
+++ b/lib/sshkit/scp.ex
@@ -36,11 +36,11 @@ defmodule SSHKit.SCP do
   ## Example
 
   ```
-  :ok = SSHKit.SCP.upload(conn, ".", "/home/code/sshkit", recursive: true)
+  :ok = SSHKit.SCP.upload(conn, "scp -t -r /home/code/sshkit", ".", recursive: true)
   ```
   """
-  def upload(connection, local, remote, options \\ []) do
-    Upload.transfer(connection, local, remote, options)
+  def upload(connection, command, source, options \\ []) do
+    Upload.transfer(connection, command, source, options)
   end
 
   @doc """
@@ -53,10 +53,10 @@ defmodule SSHKit.SCP do
   ## Example
 
   ```
-  :ok = SSHKit.SCP.download(conn, "/home/code/sshkit", "downloads", recursive: true)
+  :ok = SSHKit.SCP.download(conn, "scp -f -r /home/code/sshkit", "downloads", recursive: true)
   ```
   """
-  def download(connection, remote, local, options \\ []) do
-    Download.transfer(connection, remote, local, options)
+  def download(connection, command, target, options \\ []) do
+    Download.transfer(connection, command, target, options)
   end
 end

--- a/lib/sshkit/scp/command.ex
+++ b/lib/sshkit/scp/command.ex
@@ -25,6 +25,6 @@ defmodule SSHKit.SCP.Command do
   end
 
   defp at(command, path) do
-    "#{command} #{shellescape(path)}"
+    String.trim("#{command} #{shellescape(path)}")
   end
 end

--- a/lib/sshkit/scp/download.ex
+++ b/lib/sshkit/scp/download.ex
@@ -19,19 +19,18 @@ defmodule SSHKit.SCP.Download do
   ## Example
 
   ```
-  :ok = SSHKit.SCP.Download.transfer(conn, "/home/code/sshkit", "downloads", recursive: true)
+  :ok = SSHKit.SCP.Download.transfer(conn, "scp -f -r /home/code/sshkit", "downloads", recursive: true)
   ```
   """
-  def transfer(connection, remote, local, options \\ []) do
-    start(connection, remote, Path.expand(local), options)
+  def transfer(connection, command, target, options \\ []) do
+    start(connection, command, Path.expand(target), options)
   end
 
-  defp start(connection, remote, local, options) do
+  defp start(connection, command, target, options) do
     timeout = Keyword.get(options, :timeout, :infinity)
-    command = Command.build(:download, remote, options)
     handler = connection_handler(options)
 
-    ini = {:next, local, [], %{}, <<>>}
+    ini = {:next, target, [], %{}, <<>>}
     SSH.run(connection, command, timeout: timeout, acc: {:cont, <<0>>, ini}, fun: handler)
   end
 

--- a/test/sshkit/scp/upload_test.exs
+++ b/test/sshkit/scp/upload_test.exs
@@ -5,30 +5,30 @@ defmodule SSHKit.SCP.UploadTest do
   alias SSHKit.SCP.Upload
   alias SSHKit.SSHMock
 
-  @local "test/fixtures/local_dir"
-  @remote "/home/test/code"
+  @command "cd /home/test && scp -t -r code"
+  @source "test/fixtures/local_dir"
 
-  describe "new/3" do
+  describe "init/3" do
     test "returns a new upload struct" do
-      upload = Upload.new(@local, @remote)
-      local_expanded = @local |> Path.expand()
-      assert %Upload{local: ^local_expanded, remote: @remote} = upload
+      upload = Upload.init(@command, @source)
+      source_expanded = @source |> Path.expand()
+      assert %Upload{command: @command,source: ^source_expanded} = upload
     end
 
     test "returns a new upload struct with options" do
       options = [recursive: true]
-      upload = Upload.new(@local, @remote, options)
+      upload = Upload.init(@command, @source, options)
       assert %Upload{options: ^options} = upload
     end
 
     test "upload struct has initial state" do
-      %Upload{state: state} = Upload.new(@local, @remote)
-      current_directory = @local |> Path.expand() |> Path.dirname()
+      %Upload{state: state} = Upload.init(@command, @source)
+      current_directory = @source |> Path.expand() |> Path.dirname()
       assert state == {:next, current_directory, [["local_dir"]], []}
     end
 
     test "upload struct has a handler function" do
-      %Upload{handler: handler} = Upload.new(@local, @remote)
+      %Upload{handler: handler} = Upload.init(@command, @source)
       assert is_function(handler)
     end
   end
@@ -39,12 +39,12 @@ defmodule SSHKit.SCP.UploadTest do
     end
 
     test "returns error when trying to upload a directory non-recursively", %{conn: conn} do
-      upload = Upload.new(@local, @remote, recursive: false)
+      upload = Upload.init(@command, @source, recursive: false)
       assert {:error, _msg} = Upload.exec(upload, conn)
     end
 
     test "uses the provided timeout option", %{conn: conn} do
-      upload = Upload.new(@local, @remote, recursive: true, timeout: 55, ssh: SSHMock)
+      upload = Upload.init(@command, @source, recursive: true, timeout: 55, ssh: SSHMock)
       SSHMock |> expect(:run, fn (_, _, timeout: timeout, acc: {:cont, _}, fun: _) ->
         assert timeout == 55
         {:ok, :success}
@@ -54,10 +54,10 @@ defmodule SSHKit.SCP.UploadTest do
     end
 
     test "performs an upload", %{conn: conn} do
-      upload = Upload.new(@local, @remote, recursive: true, ssh: SSHMock)
+      upload = Upload.init(@command, @source, recursive: true, ssh: SSHMock)
       SSHMock |> expect(:run, fn (connection, command, timeout: timeout, acc: {:cont, state}, fun: handler) ->
         assert connection == conn
-        assert command == SSHKit.SCP.Command.build(:upload, upload.remote, upload.options)
+        assert command == upload.command
         assert timeout == :infinity
         assert state == upload.state
         assert handler == upload.handler
@@ -72,7 +72,7 @@ defmodule SSHKit.SCP.UploadTest do
     setup do
       channel = %SSHKit.SSH.Channel{}
       ack_message = {:data, channel, 0, <<0>>}
-      {:ok, upload: Upload.new(@local, @remote), ack: ack_message, channel: channel}
+      {:ok, upload: Upload.init(@command, @source), ack: ack_message, channel: channel}
     end
 
     test "recurses into directories", %{upload: upload, ack: ack} do
@@ -83,31 +83,31 @@ defmodule SSHKit.SCP.UploadTest do
     end
 
     test "create files in the current directory", %{upload: %Upload{handler: handler}, ack: ack} do
-      local_expanded = @local |> Path.expand()
-      state = {:next, local_expanded, [["other.txt"], []], []}
-      assert {:cont, 'C0644 61 other.txt\n', {:write, "other.txt", %File.Stat{}, ^local_expanded, [[], []], []}} = handler.(ack, state)
+      source_expanded = @source |> Path.expand()
+      state = {:next, source_expanded, [["other.txt"], []], []}
+      assert {:cont, 'C0644 61 other.txt\n', {:write, "other.txt", %File.Stat{}, ^source_expanded, [[], []], []}} = handler.(ack, state)
     end
 
     test "writes files in the current directory", %{upload: %Upload{handler: handler}, ack: ack} do
-      local_expanded = @local |> Path.expand() |> Path.join("local_dir")
-      state = {:write, "other.txt", %File.Stat{}, local_expanded, [[], []], []}
-      fs = File.stream!(Path.join(local_expanded, "other.txt"), [], 16_384)
-      write_state = {:cont, Stream.concat(fs, [<<0>>]), {:next, local_expanded, [[], []], []}}
+      source_expanded = @source |> Path.expand() |> Path.join("local_dir")
+      state = {:write, "other.txt", %File.Stat{}, source_expanded, [[], []], []}
+      fs = File.stream!(Path.join(source_expanded, "other.txt"), [], 16_384)
+      write_state = {:cont, Stream.concat(fs, [<<0>>]), {:next, source_expanded, [[], []], []}}
 
       assert write_state == handler.(ack, state)
     end
 
     test "moves upwards in the directory hierachy", %{upload: %Upload{handler: handler}, ack: ack} do
-      local_dir = @local |> Path.expand() |> Path.join("local_dir")
-      local_expanded = @local |> Path.expand()
-      state = {:next, local_dir, [[], []], []}
+      source_dir = @source |> Path.expand() |> Path.join("local_dir")
+      source_expanded = @source |> Path.expand()
+      state = {:next, source_dir, [[], []], []}
 
-      assert {:cont, 'E\n', {:next, ^local_expanded, [[]], []}} = handler.(ack, state)
+      assert {:cont, 'E\n', {:next, ^source_expanded, [[]], []}} = handler.(ack, state)
     end
 
     test "finalizes the upload", %{upload: %Upload{handler: handler}, ack: ack, channel: channel} do
-      local_expanded = @local |> Path.expand()
-      state = {:next, local_expanded, [[]], []}
+      source_expanded = @source |> Path.expand()
+      state = {:next, source_expanded, [[]], []}
 
       assert {:cont, :eof, done_state} = handler.(ack, state)
       assert done_state == {:done, nil, []}

--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -9,47 +9,60 @@ defmodule SSHKit.SCPFunctionalTest do
   describe "upload/4" do
     @tag boot: [@bootconf]
     test "sends a file", %{hosts: [host]} do
-      local = "test/fixtures/local.txt"
-      remote = "file.txt"
+      source = "test/fixtures/local.txt"
+      target = "file.txt"
+
+      command = SCP.Command.build(:upload, target, [])
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.upload(conn, local, remote)
-        assert verify_transfer(conn, local, remote)
+        assert :ok = SCP.upload(conn, command, source)
+        assert verify_transfer(conn, source, target)
       end
     end
 
     @tag boot: [@bootconf]
     test "recursive: true", %{hosts: [host]} do
-      local = "test/fixtures"
-      remote = "/home/#{host.options[:user]}/destination"
+      source = "test/fixtures"
+      target = "/home/#{host.options[:user]}/destination"
+
+      options = [recursive: true]
+      command = SCP.Command.build(:upload, target, options)
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.upload(conn, local, remote, recursive: true)
-        assert verify_transfer(conn, local, remote)
+        assert :ok = SCP.upload(conn, command, source, options)
+        assert verify_transfer(conn, source, target)
       end
     end
 
     @tag boot: [@bootconf]
     test "preserve: true", %{hosts: [host]} do
-      local = "test/fixtures/local.txt"
-      remote = "file.txt"
+      source = "test/fixtures/local.txt"
+      target = "file.txt"
+
+      options = [preserve: true]
+      command = SCP.Command.build(:upload, target, options)
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.upload(conn, local, remote, preserve: true)
-        assert verify_mode(conn, local, remote)
-        assert verify_mtime(conn, local, remote)
+        assert :ok = SCP.upload(conn, command, source, options)
+        assert verify_mode(conn, source, target)
+        assert verify_atime(conn, source, target)
+        assert verify_mtime(conn, source, target)
       end
     end
 
     @tag boot: [@bootconf]
     test "recursive: true, preserve: true", %{hosts: [host]} do
-      local = "test/fixtures/"
-      remote = "/home/#{host.options[:user]}/destination"
+      source = "test/fixtures/"
+      target = "/home/#{host.options[:user]}/destination"
+
+      options = [recursive: true, preserve: true]
+      command = SCP.Command.build(:upload, target, options)
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.upload(conn, local, remote, recursive: true, preserve: true)
-        assert verify_mode(conn, local, remote)
-        assert verify_mtime(conn, local, remote)
+        assert :ok = SCP.upload(conn, command, source, options)
+        assert verify_mode(conn, source, target)
+        assert verify_atime(conn, source, target)
+        assert verify_mtime(conn, source, target)
       end
     end
   end
@@ -57,53 +70,64 @@ defmodule SSHKit.SCPFunctionalTest do
   describe "download/4" do
     @tag boot: [@bootconf]
     test "gets a file", %{hosts: [host]} do
-      remote = "/fixtures/remote.txt"
-      local = create_local_tmp_path()
-      on_exit fn -> File.rm(local) end
+      source = "/fixtures/remote.txt"
+      target = create_local_tmp_path()
+      on_exit fn -> File.rm(target) end
+
+      command = SCP.Command.build(:download, source, [])
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.download(conn, remote, local)
-        assert verify_transfer(conn, local, remote)
+        assert :ok = SCP.download(conn, command, target)
+        assert verify_transfer(conn, target, source)
       end
     end
 
     @tag boot: [@bootconf]
     test "recursive: true", %{hosts: [host]} do
-      remote = "/fixtures"
-      local = create_local_tmp_path()
-      on_exit fn -> File.rm_rf(local) end
+      source = "/fixtures"
+      target = create_local_tmp_path()
+      on_exit fn -> File.rm_rf(target) end
+
+      options = [recursive: true]
+      command = SCP.Command.build(:download, source, options)
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.download(conn, remote, local, recursive: true)
-        assert verify_transfer(conn, local, remote)
+        assert :ok = SCP.download(conn, command, target, options)
+        assert verify_transfer(conn, target, source)
       end
     end
 
     @tag boot: [@bootconf]
     test "preserve: true", %{hosts: [host]} do
-      remote = "/fixtures/remote.txt"
-      local = create_local_tmp_path()
-      on_exit fn -> File.rm(local) end
+      source = "/fixtures/remote.txt"
+      target = create_local_tmp_path()
+      on_exit fn -> File.rm(target) end
+
+      options = [preserve: true]
+      command = SCP.Command.build(:download, source, options)
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.download(conn, remote, local, preserve: true)
-        assert verify_mode(conn, local, remote)
-        assert verify_atime(conn, local, remote)
-        assert verify_mtime(conn, local, remote)
+        assert :ok = SCP.download(conn, command, target, options)
+        assert verify_mode(conn, target, source)
+        assert verify_atime(conn, target, source)
+        assert verify_mtime(conn, target, source)
       end
     end
 
     @tag boot: [@bootconf]
     test "recursive: true, preserve: true", %{hosts: [host]} do
-      remote = "/fixtures"
-      local = create_local_tmp_path()
-      on_exit fn -> File.rm_rf(local) end
+      source = "/fixtures"
+      target = create_local_tmp_path()
+      on_exit fn -> File.rm_rf(target) end
+
+      options = [recursive: true, preserve: true]
+      command = SCP.Command.build(:download, source, options)
 
       SSH.connect host.name, host.options, fn conn ->
-        assert :ok = SCP.download(conn, remote, local, recursive: true, preserve: true)
-        assert verify_mode(conn, local, remote)
-        assert verify_atime(conn, local, remote)
-        assert verify_mtime(conn, local, remote)
+        assert :ok = SCP.download(conn, command, target, options)
+        assert verify_mode(conn, target, source)
+        assert verify_atime(conn, target, source)
+        assert verify_mtime(conn, target, source)
       end
     end
   end


### PR DESCRIPTION
<!--- Please provide a summary of your changes in the title above. -->

### Description

<!--- Please describe what you did. -->

* Build `scp` commands with the proper context (user, env, path…)
* Pass down the resulting command into the `SCP.{Upload,Download}` modules

### Motivation and Context

<!---
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Addresses #121:

> ### Expected behavior
>
> The `SSHKit.dowload/3` and `upload/3` functions should respect the context options `path`, `user`, `group`, `env` & `umask` like `SSHKit.run/2` does.
>
> ### Actual Behavior
>
> The `SSHKit.download/3` and `upload/3` functions are not yet fully context-aware. They only take the context `path` into account.

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue) 👈 kind of… we just hadn't implemented this before
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) 👈 if people are using the `SSHKit.SCP` module directly, their code will break

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
