### PR TITLE
[#121] Context-aware SSHKit downloads & uploads (B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,32 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.1.0...HEAD
 * Put fixes here
 * Improved documentation about our release process
 
+## `0.2.0` (2019-??-??)
+
+https://github.com/bitcrowd/sshkit.ex/compare/v0.1.0...v0.2.0
+
+* Put high-level summary here
+
+* The `SSHKit.download/3` and `SSHKit.upload/3` functions are now fully context-aware [#121]
+* They will respect the `user`, `env`, `path`… values set in the context
+
+### Deprecations:
+
+* Put deprecations here
+
+### Potentially breaking changes:
+
+* Put potentially breaking changes here
+
+### New features:
+
+* Put new features here
+
+### Fixes:
+
+* Put fixes here
+* Improved documentation about our release process
+
 ## `0.1.0` (2018-09-18)
 
 https://github.com/bitcrowd/sshkit.ex/compare/v0.0.3...v0.1.0

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -352,13 +352,14 @@ defmodule SSHKit do
     |> SSHKit.upload("local.txt", as: "remote.txt")
   ```
   """
-  def upload(context, path, options \\ []) do
-    as_path = Keyword.get(options, :as, Path.basename(path))
-    remote_path = build_remote_path(context, as_path)
+  def upload(context, source, options \\ []) do
+    options = Keyword.put(options, :map_cmd, &Context.build(context, &1))
+
+    target = Keyword.get(options, :as, Path.basename(source))
 
     run = fn host ->
       {:ok, res} = SSH.connect host.name, host.options, fn conn ->
-        SCP.upload(conn, path, remote_path, options)
+        SCP.upload(conn, source, target, options)
       end
       res
     end
@@ -397,21 +398,18 @@ defmodule SSHKit do
     |> SSHKit.download("remote.txt", as: "local.txt")
   ```
   """
-  def download(context, path, options \\ []) do
-    remote = build_remote_path(context, path)
-    local = Keyword.get(options, :as, Path.basename(path))
+  def download(context, source, options \\ []) do
+    options = Keyword.put(options, :map_cmd, &Context.build(context, &1))
+
+    target = Keyword.get(options, :as, Path.basename(source))
 
     run = fn host ->
       {:ok, res} = SSH.connect host.name, host.options, fn conn ->
-        SCP.download(conn, remote, local, options)
+        SCP.download(conn, source, target, options)
       end
       res
     end
 
     Enum.map(context.hosts, run)
-  end
-
-  defp build_remote_path(context, path) do
-    Path.absname(path, context.path || ".")
   end
 end

--- a/lib/sshkit/scp.ex
+++ b/lib/sshkit/scp.ex
@@ -39,8 +39,8 @@ defmodule SSHKit.SCP do
   :ok = SSHKit.SCP.upload(conn, ".", "/home/code/sshkit", recursive: true)
   ```
   """
-  def upload(connection, local, remote, options \\ []) do
-    Upload.transfer(connection, local, remote, options)
+  def upload(connection, source, target, options \\ []) do
+    Upload.transfer(connection, source, target, options)
   end
 
   @doc """
@@ -56,7 +56,7 @@ defmodule SSHKit.SCP do
   :ok = SSHKit.SCP.download(conn, "/home/code/sshkit", "downloads", recursive: true)
   ```
   """
-  def download(connection, remote, local, options \\ []) do
-    Download.transfer(connection, remote, local, options)
+  def download(connection, source, target, options \\ []) do
+    Download.transfer(connection, source, target, options)
   end
 end

--- a/lib/sshkit/scp/command.ex
+++ b/lib/sshkit/scp/command.ex
@@ -5,6 +5,8 @@ defmodule SSHKit.SCP.Command do
 
   @flags [verbose: "-v", preserve: "-p", recursive: "-r"]
 
+  def build(direction, path, options \\ [])
+
   def build(:upload, path, options) do
     scp("-t", path, options)
   end
@@ -14,7 +16,7 @@ defmodule SSHKit.SCP.Command do
   end
 
   defp scp(mode, path, options) do
-    "scp #{mode}" |> flag(options) |> at(path)
+    "scp #{mode}" |> flag(options) |> at(path) |> String.trim()
   end
 
   defp flag(command, options) do

--- a/lib/sshkit/scp/download.ex
+++ b/lib/sshkit/scp/download.ex
@@ -22,16 +22,17 @@ defmodule SSHKit.SCP.Download do
   :ok = SSHKit.SCP.Download.transfer(conn, "/home/code/sshkit", "downloads", recursive: true)
   ```
   """
-  def transfer(connection, remote, local, options \\ []) do
-    start(connection, remote, Path.expand(local), options)
+  def transfer(connection, source, target, options \\ []) do
+    start(connection, source, Path.expand(target), options)
   end
 
-  defp start(connection, remote, local, options) do
+  defp start(connection, source, target, options) do
     timeout = Keyword.get(options, :timeout, :infinity)
-    command = Command.build(:download, remote, options)
+    map_cmd = Keyword.get(options, :map_cmd, &(&1))
+    command = map_cmd.(Command.build(:download, source, options))
     handler = connection_handler(options)
 
-    ini = {:next, local, [], %{}, <<>>}
+    ini = {:next, target, [], %{}, <<>>}
     SSH.run(connection, command, timeout: timeout, acc: {:cont, <<0>>, ini}, fun: handler)
   end
 


### PR DESCRIPTION
Alternative for #139 

<!--- Please provide a summary of your changes in the title above. -->

### Description

<!--- Please describe what you did. -->

* Allow `scp` commands to be customized/mapped
* Use mapping to apply SSHKit context to `scp` commands

### Motivation and Context

<!---
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Addresses #121:

> ### Expected behavior
>
> The `SSHKit.dowload/3` and `upload/3` functions should respect the context options `path`, `user`, `group`, `env` & `umask` like `SSHKit.run/2` does.
>
> ### Actual Behavior
>
> The `SSHKit.download/3` and `upload/3` functions are not yet fully context-aware. They only take the context `path` into account.

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue) 👈 kind of… we just hadn't implemented this before
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly. 👈 I don't know whether we actually want to document the `:map_cmd` option as I don't think it is of much use for other use-cases
- [x] I have added tests to cover my changes (with unit and/or functional tests). 👈 downloads weren't tested before, so I didn't do that here (there's a separate ticket for that), but we can use the uploads tests – which I've updated – as a template
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).