### PR TITLE
Update return values in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ context =
   |> SSHKit.umask("022")
   |> SSHKit.env(%{"NODE_ENV" => "production"})
 
-:ok = SSHKit.upload(context, ".", recursive: true)
-:ok = SSHKit.run(context, "yarn install")
+[:ok, :ok] = SSHKit.upload(context, ".", recursive: true)
+[{:ok, _, 0}, {:ok, _, 0}] = SSHKit.run(context, "yarn install")
 ```
 
 The [`SSHKit`](https://hexdocs.pm/sshkit/SSHKit.html) module documentation has more guidance and examples for the DSL.

--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -4,7 +4,6 @@ defmodule SSHKit do
 
   ```
   hosts = ["1.eg.io", {"2.eg.io", port: 2222}]
-  hosts = [%SSHKit.Host{name: "3.eg.io", options: [port: 2223]} | hosts]
 
   context =
     SSHKit.context(hosts)
@@ -14,8 +13,8 @@ defmodule SSHKit do
     |> SSHKit.umask("022")
     |> SSHKit.env(%{"NODE_ENV" => "production"})
 
-  :ok = SSHKit.upload(context, ".", recursive: true)
-  :ok = SSHKit.run(context, "yarn install", mode: :parallel)
+  [:ok, :ok] = SSHKit.upload(context, ".", recursive: true)
+  [{:ok, _, 0}, {:ok, _, 0}] = SSHKit.run(context, "yarn install", mode: :parallel)
   ```
   """
 


### PR DESCRIPTION
The return values of `SSHKit.run` and `SSHKit.upload` in parts of the documentation were still using a draft version from the initial README-driven development phase 🙄 😇 This updates the examples so they match the actual behavior ✌️ 