### PR TITLE
[#147] Fix deprecation warning in Elixir 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ matrix:
       otp_release: 18.1
       services: docker
     - elixir: 1.5
-      otp_release: 20.2
+      otp_release: 20.3
       services: docker
     - elixir: 1.6
       otp_release: 19.0
       services: docker
     - elixir: 1.6
-      otp_release: 20.2
+      otp_release: 20.3
       services: docker
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.1.0...HEAD
 
 * Put fixes here
 * Improved documentation about our release process
+* Fix an Elixir 1.8 deprecation warning (#147)
 
 ## `0.2.0` (2019-??-??)
 

--- a/lib/sshkit/scp/command.ex
+++ b/lib/sshkit/scp/command.ex
@@ -20,10 +20,12 @@ defmodule SSHKit.SCP.Command do
   end
 
   defp flag(command, options) do
-    @flags
-    |> Enum.filter(fn {key, _} -> Keyword.get(options, key, false) end)
-    |> Enum.into([command], fn {_, flag} -> flag end)
-    |> Enum.join(" ")
+    flags =
+      @flags
+      |> Enum.filter(fn {key, _} -> Keyword.get(options, key, false) end)
+      |> Enum.map(fn {_, flag} -> flag end)
+
+    Enum.join([command] ++ flags, " ")
   end
 
   defp at(command, path) do


### PR DESCRIPTION
<!--- Please provide a summary of your changes in the title above. -->

### Description

Address #147: Fix a deprecation due to `Enum.into/3` a non-empty list.

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
