### PR TITLE
Expose `:ssh_connection.subsystem/4`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.2...v0.0.3
 * Improved documentation [#67]
 * Added support for passing an anonymous function to `SSH.connect` [#72]
 * Add support for passing a `dry_run` flag to `SSHKit.SSH.connect` [#79]
+* Add support for `:ssh_connection.subsystem/4`
 
 ### Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.2.0...HEAD
 ### Fixes:
 
 <!-- Put fixes here -->
+* Add support for initializing subsystems using `SSH.Channel.subsystem`
+  * Subsystems allow applications or functions to use SSH as a protocol.
+    Examples of this are SFTP and NETCONF over SSH.
 
 ## `0.2.0` (2019-10-17)
 
@@ -89,7 +92,6 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.0.2...v0.0.3
 * Improved documentation [#67]
 * Added support for passing an anonymous function to `SSH.connect` [#72]
 * Add support for passing a `dry_run` flag to `SSHKit.SSH.connect` [#79]
-* Add support for `:ssh_connection.subsystem/4`
 
 ### Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ https://github.com/bitcrowd/sshkit.ex/compare/v0.2.0...HEAD
 ### New features:
 
 <!-- Put new features here -->
+* Add support for initializing subsystems using `SSH.Channel.subsystem`
+  * Subsystems allow applications or functions to use SSH as a protocol.
+    Examples of this are SFTP and NETCONF over SSH.
 
 ### Fixes:
 
 <!-- Put fixes here -->
-* Add support for initializing subsystems using `SSH.Channel.subsystem`
-  * Subsystems allow applications or functions to use SSH as a protocol.
-    Examples of this are SFTP and NETCONF over SSH.
 
 ## `0.2.0` (2019-10-17)
 

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -39,6 +39,10 @@ defmodule SSHKit.SSH.Channel do
     end
   end
 
+  defp build(connection, id, impl) do
+    %Channel{connection: connection, type: :session, id: id, impl: impl}
+  end
+
   @doc """
   Activates a subsystem on a channel.
 
@@ -53,10 +57,6 @@ defmodule SSHKit.SSH.Channel do
     impl = Keyword.get(options, :impl, :ssh_connection)
 
     impl.subsystem(channel.connection.ref, channel.id, to_charlist(subsystem), timeout)
-  end
-
-  defp build(connection, id, impl) do
-    %Channel{connection: connection, type: :session, id: id, impl: impl}
   end
 
   @doc """

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -42,26 +42,17 @@ defmodule SSHKit.SSH.Channel do
   @doc """
   Activates a subsystem on a channel.
 
-  On success, returns `:ok`. On failure, returns `{:error, reason}`.
+  Returns `:success`, `:failure` or `{:error, reason}`.
 
   For more details, see [`:ssh_connection.subsystem/4`](http://erlang.org/doc/man/ssh_connection.html#subsystem-4).
   """
   @spec subsystem(channel :: struct(), subsystem :: String.t(), options :: list()) ::
-          :ok | {:error, reason :: String.t()}
+          :success | :failure | {:error, reason :: String.t()}
   def subsystem(channel, subsystem, options \\ []) do
     timeout = Keyword.get(options, :timeout, :infinity)
     impl = Keyword.get(options, :impl, :ssh_connection)
 
-    case impl.subsystem(channel.connection.ref, channel.id, to_charlist(subsystem), timeout) do
-      :success ->
-        :ok
-
-      :failure ->
-        {:error, :failure}
-
-      err ->
-        err
-    end
+    impl.subsystem(channel.connection.ref, channel.id, to_charlist(subsystem), timeout)
   end
 
   defp build(connection, id, impl) do

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -39,6 +39,15 @@ defmodule SSHKit.SSH.Channel do
     end
   end
 
+  @doc """
+  Activates a subsystem on a channel.
+
+  On success, returns `:ok`. On failure, returns `{:error, reason}`.
+
+  For more details, see [`:ssh_connection.subsystem/4`](http://erlang.org/doc/man/ssh_connection.html#subsystem-4).
+  """
+  @spec subsystem(channel :: struct(), subsystem :: String.t(), options :: list()) ::
+          :ok | {:error, reason :: String.t()}
   def subsystem(channel, subsystem, options \\ []) do
     timeout = Keyword.get(options, :timeout, :infinity)
     impl = Keyword.get(options, :impl, :ssh_connection)

--- a/lib/sshkit/ssh/channel.ex
+++ b/lib/sshkit/ssh/channel.ex
@@ -39,6 +39,22 @@ defmodule SSHKit.SSH.Channel do
     end
   end
 
+  def subsystem(channel, subsystem, options \\ []) do
+    timeout = Keyword.get(options, :timeout, :infinity)
+    impl = Keyword.get(options, :impl, :ssh_connection)
+
+    case impl.subsystem(channel.connection.ref, channel.id, to_charlist(subsystem), timeout) do
+      :success ->
+        :ok
+
+      :failure ->
+        {:error, :failure}
+
+      err ->
+        err
+    end
+  end
+
   defp build(connection, id, impl) do
     %Channel{connection: connection, type: :session, id: id, impl: impl}
   end

--- a/test/sshkit/ssh/channel_functional_test.exs
+++ b/test/sshkit/ssh/channel_functional_test.exs
@@ -12,22 +12,21 @@ defmodule SSHKit.SSH.ChannelFunctionalTest do
       {:ok, channel} = SSHKit.SSH.Channel.open(conn)
       :success = SSHKit.SSH.Channel.subsystem(channel, "greeting-subsystem")
 
+      assert readline(channel) == "Hello, who am I talking to?\n"
+
       SSHKit.SSH.Channel.send(channel, "Lorem\n")
 
-      [welcome_message, response_message, _] = get_messages(channel)
-
-      assert welcome_message == "Hello, who am I talking to?"
-      assert response_message == "It's nice to meet you Lorem"
+      assert readline(channel) == "It's nice to meet you Lorem\n"
     end
   end
 
-  defp get_messages(channel, message \\ "") do
+  defp readline(channel, message \\ "") do
     {:ok, {:data, _channel, _type, next_line}} = SSHKit.SSH.Channel.recv(channel)
 
-    if String.ends_with?(next_line, "Lorem\n") do
-      String.split("#{message}#{next_line}", "\n")
+    if String.ends_with?(next_line, "\n") do
+      "#{message}#{next_line}"
     else
-      get_messages(channel, "#{message}#{next_line}")
+      readline(channel, "#{message}#{next_line}")
     end
   end
 end

--- a/test/sshkit/ssh/channel_functional_test.exs
+++ b/test/sshkit/ssh/channel_functional_test.exs
@@ -1,0 +1,23 @@
+defmodule SSHKit.SSH.ChannelFunctionalTest do
+  @moduledoc false
+
+  use SSHKit.FunctionalCase, async: true
+
+  @bootconf [user: "me", password: "pass"]
+
+  describe "Channel.subsystem/3" do
+    @tag boot: [@bootconf]
+    test "with user", %{hosts: [host]} do
+      {:ok, conn} = SSHKit.SSH.connect(host.name, host.options)
+
+      {:ok, channel} = SSHKit.SSH.Channel.open(conn)
+      :success = SSHKit.SSH.Channel.subsystem(channel, "greeting-subsystem")
+      SSHKit.SSH.Channel.send(channel, "Lorem\n")
+      {:ok, {:data, _channel, _type, welcome_message}} = SSHKit.SSH.Channel.recv(channel)
+      {:ok, {:data, _channel, _type, response_message}} = SSHKit.SSH.Channel.recv(channel)
+
+      assert welcome_message == "Hello, who am I talking to?\n"
+      assert response_message == "It's nice to meet you Lorem\n"
+    end
+  end
+end

--- a/test/sshkit/ssh/channel_functional_test.exs
+++ b/test/sshkit/ssh/channel_functional_test.exs
@@ -14,7 +14,7 @@ defmodule SSHKit.SSH.ChannelFunctionalTest do
 
       assert readline(channel) == "Hello, who am I talking to?\n"
 
-      SSHKit.SSH.Channel.send(channel, "Lorem\n")
+      :ok = SSHKit.SSH.Channel.send(channel, "Lorem\n")
 
       assert readline(channel) == "It's nice to meet you Lorem\n"
     end

--- a/test/sshkit/ssh/channel_functional_test.exs
+++ b/test/sshkit/ssh/channel_functional_test.exs
@@ -9,15 +9,25 @@ defmodule SSHKit.SSH.ChannelFunctionalTest do
     @tag boot: [@bootconf]
     test "with user", %{hosts: [host]} do
       {:ok, conn} = SSHKit.SSH.connect(host.name, host.options)
-
       {:ok, channel} = SSHKit.SSH.Channel.open(conn)
       :success = SSHKit.SSH.Channel.subsystem(channel, "greeting-subsystem")
-      SSHKit.SSH.Channel.send(channel, "Lorem\n")
-      {:ok, {:data, _channel, _type, welcome_message}} = SSHKit.SSH.Channel.recv(channel)
-      {:ok, {:data, _channel, _type, response_message}} = SSHKit.SSH.Channel.recv(channel)
 
-      assert welcome_message == "Hello, who am I talking to?\n"
-      assert response_message == "It's nice to meet you Lorem\n"
+      SSHKit.SSH.Channel.send(channel, "Lorem\n")
+
+      [welcome_message, response_message, _] = get_messages(channel)
+
+      assert welcome_message == "Hello, who am I talking to?"
+      assert response_message == "It's nice to meet you Lorem"
+    end
+  end
+
+  defp get_messages(channel, message \\ "") do
+    {:ok, {:data, _channel, _type, next_line}} = SSHKit.SSH.Channel.recv(channel)
+
+    if String.ends_with?(next_line, "Lorem\n") do
+      String.split("#{message}#{next_line}", "\n")
+    else
+      get_messages(channel, "#{message}#{next_line}")
     end
   end
 end

--- a/test/sshkit/ssh/channel_test.exs
+++ b/test/sshkit/ssh/channel_test.exs
@@ -64,6 +64,15 @@ defmodule SSHKit.SSH.ChannelTest do
       :success = subsystem(chan, "example-subsystem", impl: impl)
     end
 
+    test "requests a subsystem with a specific timeout",  %{chan: chan, impl: impl} do
+      impl |> expect(:subsystem, fn (_, _, _, timeout) ->
+        assert timeout == 3000
+        :success
+      end)
+
+      :success = subsystem(chan, "example-subsystem", timeout: 3000, impl: impl)
+    end
+
     test "returns a failure if the subsystem could not be initialized", %{chan: chan, impl: impl} do
       impl |> expect(:subsystem, fn (_, _, _, _) ->
         :failure

--- a/test/sshkit/ssh/channel_test.exs
+++ b/test/sshkit/ssh/channel_test.exs
@@ -51,6 +51,36 @@ defmodule SSHKit.SSH.ChannelTest do
     end
   end
 
+  describe "subsystem/3" do
+    test "requests a subsystem", %{chan: chan, impl: impl} do
+      impl |> expect(:subsystem, fn (connection_ref, channel_id, subsystem, timeout) ->
+        assert connection_ref == chan.connection.ref
+        assert channel_id == chan.id
+        assert subsystem  == 'example-subsystem'
+        assert timeout == :infinity
+        :success
+      end)
+
+      :success = subsystem(chan, "example-subsystem", impl: impl)
+    end
+
+    test "returns a failure if the subsystem could not be initialized", %{chan: chan, impl: impl} do
+      impl |> expect(:subsystem, fn (_, _, _, _) ->
+        :failure
+      end)
+
+      :failure = subsystem(chan, "example-subsystem", impl: impl)
+    end
+
+    test "returns an error if the initialization times out", %{chan: chan, impl: impl} do
+      impl |> expect(:subsystem, fn (_, _, _, _) ->
+        {:error, :timeout}
+      end)
+
+      {:error, :timeout} = subsystem(chan, "example-subsystem", impl: impl)
+    end
+  end
+
   describe "close/1" do
     test "closes the channel", %{chan: chan, impl: impl} do
       impl |> expect(:close, fn (connection_ref, channel_id) ->

--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN echo "%passwordless-sudoers ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/y
 # Add fixture data for tests
 COPY fixtures /fixtures
 
-# Sets up a subsystem
-RUN echo "Subsystem greeting-subsystem echo Hello, who am I talking to?; while :; do read varname;echo It\'s nice to meet you \$varname;done" >> /etc/ssh/sshd_config
+# Set up a subsystem
+RUN echo "Subsystem greeting-subsystem echo Hello, who am I talking to?; while :; do read varname; echo It\'s nice to meet you \$varname; done" >> /etc/ssh/sshd_config
 
 # Run SSH daemon and expose the standard SSH port.
 EXPOSE 22

--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -27,6 +27,9 @@ RUN echo "%passwordless-sudoers ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/y
 # Add fixture data for tests
 COPY fixtures /fixtures
 
+# Sets up a subsystem
+RUN echo "Subsystem greeting-subsystem echo Hello, who am I talking to?; while :; do read varname;echo It\'s nice to meet you \$varname;done" >> /etc/ssh/sshd_config
+
 # Run SSH daemon and expose the standard SSH port.
 EXPOSE 22
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -16,6 +16,7 @@ defmodule SSHKit.SSH.Channel.Impl do
   @type chan :: integer()
 
   @callback session_channel(conn, integer(), integer(), timeout()) :: {:ok, chan} | {:error, any()}
+  @callback subsystem(conn, chan, charlist(), keyword()) :: :success | :failure | {:error, :timeout} | {:error, :closed}
   @callback close(conn, chan) :: :ok
   @callback exec(conn, chan, binary(), timeout()) :: :success | :failure | {:error, :timeout} | {:error, :closed}
   @callback ptty_alloc(conn, chan, keyword(), timeout()) :: :success | :failure | {:error, :timeout} | {:error, :closed}


### PR DESCRIPTION
### Description
Exposes `:ssh_connection.subsystem/4` in SSHKit.

This is a followup on #137, I can't (or don't know how to) actually attach these changes to the same issue besides mentioning it.

Tests are written and feedback in that PR is applied. Please double check if what I'm doing in the unit tests makes sense because this was my first time working with Mox and it was somewhat trial and error to get there 😄 

The unit test for the timeout feels a bit silly, I'm not sure if it adds a lot. I thought about adding it as a functional test by adding a clause in the subsystem that sleeps for a bit, but I doubt if the added complexity to the currently pretty straightforward test subsystem is worth it.

### Motivation and Context
I'm using the Netconf driver that @derekkraan wrote, and activating the Netconf subsystem is required for that.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (with unit and/or functional tests).
- [x] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
