### PR TITLE
Add run_opts to SSHKit.run with default empty list

### DIFF
--- a/lib/sshkit.ex
+++ b/lib/sshkit.ex
@@ -307,12 +307,12 @@ defmodule SSHKit do
   assert "Hello World!\n" == stdout
   ```
   """
-  def run(context, command) do
+  def run(context, command, run_opts = [] \\ []) do
     cmd = Context.build(context, command)
 
     run = fn host ->
       {:ok, conn} = SSH.connect(host.name, host.options)
-      res = SSH.run(conn, cmd)
+      res = SSH.run(conn, cmd, run_opts)
       :ok = SSH.close(conn)
       res
     end


### PR DESCRIPTION
This would allow us to do things like setup a custom capture function for messages while still getting to use the higher level contexts abstraction.

### Description

Added a 3 arg to SSHKit.exe that defaults to an empty list for run options, to be used with SSHKit.SSH.run underneath.

### Motivation and Context
[This issue reply](https://github.com/bitcrowd/sshkit.ex/issues/150#issuecomment-543114944) explained how to use the underlying functions, but I'd really like to be able to keep using the conexts abstraction. This should let me do both.


### Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Haven't updated docs or tests because I think the existing ones already cover this.

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
