### PR TITLE
Better error handling for scp uploads

### DIFF
--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -218,19 +218,16 @@ defmodule SSHKit.SCP.Upload do
     {:cont, {:error, "SCP channel closed before completing the transfer"}}
   end
 
-  defp warning(_, state = {name, cwd, stack, errs}, buffer) do
+  defp warning(options, {name, _file, _stat, cwd, stack, errs}, buffer) do
+    warning(options, {name, cwd, stack, errs}, buffer)
+  end
+
+  defp warning(options, state = {_name, cwd, stack, errs}, buffer) do
     if String.last(buffer) == "\n" do
-      {:cont, {name, cwd, stack, errs ++ [String.trim(buffer)]}}
+      next(options, cwd, stack, errs ++ [String.trim(buffer)])
     else
       {:cont, {:warning, state, buffer}}
     end
-  end
-
-  # There are warnings that we don't understand correctly. If that is the case
-  # we treat them as errors.
-  # For example a permission denied error will be treated as such.
-  defp warning(options, state, buffer) do
-    fatal(options, state, buffer)
   end
 
   defp fatal(_, state, buffer) do

--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -107,6 +107,9 @@ defmodule SSHKit.SCP.Upload do
         {:data, _, 0, data} ->
           handle_error_data(state, options, data)
 
+        {:data, _, 1, data} ->
+          fatal(options, state, data)
+
         {:exit_status, _, status} ->
           exited(options, state, status)
 
@@ -221,6 +224,13 @@ defmodule SSHKit.SCP.Upload do
     else
       {:cont, {:warning, state, buffer}}
     end
+  end
+
+  # There are warnings that we don't understand correctly. If that is the case
+  # we treat them as errors.
+  # For example a permission denied error will be treated as such.
+  defp warning(options, state, buffer) do
+    fatal(options, state, buffer)
   end
 
   defp fatal(_, state, buffer) do

--- a/test/sshkit/scp_functional_test.exs
+++ b/test/sshkit/scp_functional_test.exs
@@ -52,6 +52,17 @@ defmodule SSHKit.SCPFunctionalTest do
         assert verify_mtime(conn, local, remote)
       end)
     end
+
+    @tag boot: [@bootconf]
+    test "uploads to nonexistent target directory (recursive: true)", %{hosts: [host]} do
+      local = "test/fixtures/local_dir"
+      remote = "/some/nonexistent/destination"
+
+      SSH.connect(host.name, host.options, fn conn ->
+        assert {:error, msg} = SCP.upload(conn, local, remote, recursive: true)
+        assert msg =~ "scp: /some/nonexistent/destination: No such file or directory"
+      end)
+    end
   end
 
   describe "download/4" do

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -159,6 +159,28 @@ defmodule SSHKitFunctionalTest do
       assert verify_transfer(context, local, Path.basename(local))
     end
 
+    test "uploads a file to a directory that does not exist", %{hosts: hosts} do
+      local = "test/fixtures/local.txt"
+
+      context =
+        hosts
+        |> SSHKit.context()
+        |> SSHKit.path("/otp/releases")
+
+      assert [error: _, error: _] = SSHKit.upload(context, local)
+    end
+
+    test "uploads a file to a directory we have no access to", %{hosts: hosts} do
+      local = "test/fixtures/local.txt"
+
+      context =
+        hosts
+        |> SSHKit.context()
+        |> SSHKit.path("/")
+
+      assert [error: _, error: _] = SSHKit.upload(context, local)
+    end
+
     test "recursive: true", %{hosts: [host | _] = hosts} do
       local = "test/fixtures"
       remote = "/home/#{host.options[:user]}/fixtures"

--- a/test/sshkit_functional_test.exs
+++ b/test/sshkit_functional_test.exs
@@ -167,7 +167,10 @@ defmodule SSHKitFunctionalTest do
         |> SSHKit.context()
         |> SSHKit.path("/otp/releases")
 
-      assert [error: _, error: _] = SSHKit.upload(context, local)
+      assert [
+               error: "sh: cd: line 1: can't cd to /otp/releases",
+               error: "sh: cd: line 1: can't cd to /otp/releases"
+             ] = SSHKit.upload(context, local)
     end
 
     test "uploads a file to a directory we have no access to", %{hosts: hosts} do
@@ -178,7 +181,10 @@ defmodule SSHKitFunctionalTest do
         |> SSHKit.context()
         |> SSHKit.path("/")
 
-      assert [error: _, error: _] = SSHKit.upload(context, local)
+      assert [
+               error: "SCP exited with non-zero exit code 1: scp: local.txt: Permission denied",
+               error: "SCP exited with non-zero exit code 1: scp: local.txt: Permission denied"
+             ] = SSHKit.upload(context, local)
     end
 
     test "recursive: true", %{hosts: [host | _] = hosts} do


### PR DESCRIPTION
In the context of #160 we debugged a bit into certain cases, when we have files that do not exists or when we have no permission. 
We have a very first draft in handling those cases.

Probably this is also liked to #62. 

### Description

We added some clauses that treat output on `stderr` or warnings that we do not recognize to be `fatal` and lead to error output. 

### Motivation and Context

<!---
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

### Types of changes

<!---
What types of changes does your code introduce?
Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!---
Please go over the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (with unit and/or functional tests).
- [ ] I have added a note to CHANGELOG.md if necessary (in the `## master` section).
