### PR TITLE
Switch to actions/setup-elixir@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: "23.0"
           elixir-version: "1.11.2"
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: "23.0"
           elixir-version: "1.11.2"
@@ -52,31 +52,38 @@ jobs:
 
   test:
     name: Test Elixir ${{ matrix.elixir }}, OTP ${{ matrix.erlang }}
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
         include:
           - erlang: "23.0"
             elixir: "1.11.2"
+            os: "ubuntu-latest"
           - erlang: "23.0"
             elixir: "1.10.3"
+            os: "ubuntu-latest"
           - erlang: "22.3"
             elixir: "1.9.4"
+            os: "ubuntu-latest"
           - erlang: "21.3"
             elixir: "1.8.2"
+            os: "ubuntu-latest"
           - erlang: "20.3.1"
             elixir: "1.7.4"
+            os: "ubuntu-latest"
           - erlang: "19.3"
             elixir: "1.6.6"
+            os: "ubuntu-18.04"
           - erlang: "18.3"
             elixir: "1.5.3"
+            os: "ubuntu-18.04"
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.erlang }}
           elixir-version: ${{ matrix.elixir }}


### PR DESCRIPTION
The old setup-elixir build is unmaintained and does not work anymore (see #161) .

https://github.com/actions/setup-elixir#setup-elixir

The new official one is:
https://github.com/erlef/setup-beam

from the Erlang Ecosystem Foundation