### PR TITLE
Fix Elixir 1.17+ warning (Single-quote charlists are deprecated, use ~c instead)

### DIFF
--- a/lib/sshkit/scp/upload.ex
+++ b/lib/sshkit/scp/upload.ex
@@ -150,7 +150,7 @@ defmodule SSHKit.SCP.Upload do
   end
 
   defp next(_, cwd, [[] | dirs], errs) do
-    {:cont, 'E\n', {:next, Path.dirname(cwd), dirs, errs}}
+    {:cont, ~c"E\n", {:next, Path.dirname(cwd), dirs, errs}}
   end
 
   defp next(options, cwd, [[name | rest] | dirs], errs) do
@@ -174,17 +174,17 @@ defmodule SSHKit.SCP.Upload do
   end
 
   defp time(_, type, name, stat, cwd, stack, errs) do
-    directive = 'T#{stat.mtime} 0 #{stat.atime} 0\n'
+    directive = ~c"T#{stat.mtime} 0 #{stat.atime} 0\n"
     {:cont, directive, {type, name, stat, cwd, stack, errs}}
   end
 
   defp directory(_, name, stat, cwd, stack, errs) do
-    directive = 'D#{modefmt(stat.mode)} 0 #{name}\n'
+    directive = ~c"D#{modefmt(stat.mode)} 0 #{name}\n"
     {:cont, directive, {:next, Path.join(cwd, name), stack, errs}}
   end
 
   defp regular(_, name, stat, cwd, stack, errs) do
-    directive = 'C#{modefmt(stat.mode)} #{stat.size} #{name}\n'
+    directive = ~c"C#{modefmt(stat.mode)} #{stat.size} #{name}\n"
     {:cont, directive, {:write, name, stat, cwd, stack, errs}}
   end
 

--- a/test/sshkit/scp/upload_test.exs
+++ b/test/sshkit/scp/upload_test.exs
@@ -101,7 +101,7 @@ defmodule SSHKit.SCP.UploadTest do
       %Upload{handler: handler, state: {:next, cwd, [["local_dir"]], []} = state} = upload
       next_path = Path.join(cwd, "local_dir")
 
-      assert {:cont, 'D0755 0 local_dir\n', {:next, ^next_path, [["other.txt"], []], []}} =
+      assert {:cont, ~c"D0755 0 local_dir\n", {:next, ^next_path, [["other.txt"], []], []}} =
                handler.(ack, state)
     end
 
@@ -109,7 +109,7 @@ defmodule SSHKit.SCP.UploadTest do
       source_expanded = @source |> Path.expand()
       state = {:next, source_expanded, [["other.txt"], []], []}
 
-      assert {:cont, 'C0644 61 other.txt\n',
+      assert {:cont, ~c"C0644 61 other.txt\n",
               {:write, "other.txt", %File.Stat{}, ^source_expanded, [[], []], []}} =
                handler.(ack, state)
     end
@@ -128,7 +128,7 @@ defmodule SSHKit.SCP.UploadTest do
       source_expanded = @source |> Path.expand()
       state = {:next, source_dir, [[], []], []}
 
-      assert {:cont, 'E\n', {:next, ^source_expanded, [[]], []}} = handler.(ack, state)
+      assert {:cont, ~c"E\n", {:next, ^source_expanded, [[]], []}} = handler.(ack, state)
     end
 
     test "finalizes the upload", %{upload: %Upload{handler: handler}, ack: ack, channel: channel} do
@@ -175,7 +175,7 @@ defmodule SSHKit.SCP.UploadTest do
       {name, cwd, _stack, _errs} = state
       msg = {:data, channel, 0, <<1, "error message\n">>}
 
-      assert {:cont, 'D0755 0 local_dir\n',
+      assert {:cont, ~c"D0755 0 local_dir\n",
               {name, cwd <> "/local_dir", [["other.txt"], []], ["error message"]}} ==
                handler.(msg, state)
     end
@@ -189,7 +189,7 @@ defmodule SSHKit.SCP.UploadTest do
       state = {:write, "local.txt", %{}, cwd, stack, []}
       msg = {:data, channel, 0, <<1, "error message\n">>}
 
-      assert {:cont, 'D0755 0 local_dir\n',
+      assert {:cont, ~c"D0755 0 local_dir\n",
               {name, cwd <> "/local_dir", [["other.txt"], []], ["error message"]}} ==
                handler.(msg, state)
     end

--- a/test/sshkit/ssh/channel_test.exs
+++ b/test/sshkit/ssh/channel_test.exs
@@ -59,7 +59,7 @@ defmodule SSHKit.SSH.ChannelTest do
       |> expect(:subsystem, fn connection_ref, channel_id, subsystem, timeout ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
-        assert subsystem == 'example-subsystem'
+        assert subsystem == ~c"example-subsystem"
         assert timeout == :infinity
         :success
       end)
@@ -115,7 +115,7 @@ defmodule SSHKit.SSH.ChannelTest do
       |> expect(:exec, fn connection_ref, channel_id, command, timeout ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
-        assert command == 'cmd arg1 arg2'
+        assert command == ~c"cmd arg1 arg2"
         assert timeout == :infinity
         :success
       end)
@@ -128,12 +128,12 @@ defmodule SSHKit.SSH.ChannelTest do
       |> expect(:exec, fn connection_ref, channel_id, command, timeout ->
         assert connection_ref == chan.connection.ref
         assert channel_id == chan.id
-        assert command == 'cmd arg1 arg2'
+        assert command == ~c"cmd arg1 arg2"
         assert timeout == :infinity
         :success
       end)
 
-      assert exec(chan, 'cmd arg1 arg2') == :success
+      assert exec(chan, ~c"cmd arg1 arg2") == :success
     end
 
     test "executes a command with a specific timeout", %{chan: chan, impl: impl} do
@@ -179,8 +179,8 @@ defmodule SSHKit.SSH.ChannelTest do
     end
 
     test "sends charlist data across channel", %{chan: chan, impl: impl} do
-      impl |> expect(:send, sends(chan, 0, 'charlist data', :infinity, :ok))
-      assert Channel.send(chan, 'charlist data') == :ok
+      impl |> expect(:send, sends(chan, 0, ~c"charlist data", :infinity, :ok))
+      assert Channel.send(chan, ~c"charlist data") == :ok
     end
 
     test "sends stream data across channel", %{chan: chan, impl: impl} do

--- a/test/sshkit/ssh/connection_test.exs
+++ b/test/sshkit/ssh/connection_test.exs
@@ -16,7 +16,7 @@ defmodule SSHKit.SSH.ConnectionTest do
     test "opens a connection", %{impl: impl} do
       impl
       |> expect(:connect, fn host, port, opts, timeout ->
-        assert host == 'test.io'
+        assert host == ~c"test.io"
         assert port == 22
         assert opts == [user_interaction: false]
         assert timeout == :infinity
@@ -26,7 +26,7 @@ defmodule SSHKit.SSH.ConnectionTest do
       {:ok, conn} = open("test.io", impl: impl)
 
       assert conn == %Connection{
-               host: 'test.io',
+               host: ~c"test.io",
                port: 22,
                options: [user_interaction: false],
                ref: :connection_ref,
@@ -38,8 +38,8 @@ defmodule SSHKit.SSH.ConnectionTest do
       impl
       |> expect(:connect, fn _, port, opts, _ ->
         assert port == 666
-        assert opts[:user] == 'me'
-        assert opts[:password] == 'secret'
+        assert opts[:user] == ~c"me"
+        assert opts[:password] == ~c"secret"
         assert opts[:user_interaction] == false
         {:ok, :ref_with_port_user_pass}
       end)
@@ -47,9 +47,9 @@ defmodule SSHKit.SSH.ConnectionTest do
       {:ok, conn} = open("test.io", port: 666, user: "me", password: "secret", impl: impl)
 
       assert conn == %Connection{
-               host: 'test.io',
+               host: ~c"test.io",
                port: 666,
-               options: [user_interaction: false, user: 'me', password: 'secret'],
+               options: [user_interaction: false, user: ~c"me", password: ~c"secret"],
                ref: :ref_with_port_user_pass,
                impl: impl
              }
@@ -58,8 +58,8 @@ defmodule SSHKit.SSH.ConnectionTest do
     test "opens a connection with user interaction option set to true", %{impl: impl} do
       impl
       |> expect(:connect, fn _, _, opts, _ ->
-        assert opts[:user] == 'me'
-        assert opts[:password] == 'secret'
+        assert opts[:user] == ~c"me"
+        assert opts[:password] == ~c"secret"
         assert opts[:user_interaction] == true
         {:ok, :ref_with_user_interaction}
       end)
@@ -69,8 +69,8 @@ defmodule SSHKit.SSH.ConnectionTest do
       {:ok, conn} = open("test.io", options)
 
       assert conn == %Connection{
-               host: 'test.io',
-               options: [user: 'me', password: 'secret', user_interaction: true],
+               host: ~c"test.io",
+               options: [user: ~c"me", password: ~c"secret", user_interaction: true],
                port: 22,
                ref: :ref_with_user_interaction,
                impl: impl
@@ -107,7 +107,7 @@ defmodule SSHKit.SSH.ConnectionTest do
     test "converts host to charlist", %{impl: impl} do
       impl
       |> expect(:connect, fn host, _, _, _ ->
-        assert host == 'test.io'
+        assert host == ~c"test.io"
         {:ok, :ref}
       end)
 
@@ -117,8 +117,8 @@ defmodule SSHKit.SSH.ConnectionTest do
     test "converts option values to charlists", %{impl: impl} do
       impl
       |> expect(:connect, fn _, _, opts, _ ->
-        assert {:user, 'me'} in opts
-        assert {:password, 'secret'} in opts
+        assert {:user, ~c"me"} in opts
+        assert {:password, ~c"secret"} in opts
         {:ok, :ref}
       end)
 
@@ -148,7 +148,7 @@ defmodule SSHKit.SSH.ConnectionTest do
       end)
 
       conn = %Connection{
-        host: 'foo.io',
+        host: ~c"foo.io",
         port: 22,
         options: [user_interaction: false],
         ref: :connection_ref,
@@ -162,9 +162,9 @@ defmodule SSHKit.SSH.ConnectionTest do
   describe "reopen/2" do
     test "opens a new connection with the same options as the existing connection", %{impl: impl} do
       conn = %Connection{
-        host: 'test.io',
+        host: ~c"test.io",
         port: 22,
-        options: [user_interaction: false, user: 'me'],
+        options: [user_interaction: false, user: ~c"me"],
         ref: :connection_ref,
         impl: impl
       }
@@ -184,9 +184,9 @@ defmodule SSHKit.SSH.ConnectionTest do
 
     test "reopens a connection on new port", %{impl: impl} do
       conn = %Connection{
-        host: 'test.io',
+        host: ~c"test.io",
         port: 22,
-        options: [user_interaction: false, user: 'me'],
+        options: [user_interaction: false, user: ~c"me"],
         ref: :connection_ref,
         impl: impl
       }
@@ -204,7 +204,7 @@ defmodule SSHKit.SSH.ConnectionTest do
 
     test "errors when unable to open connection", %{impl: impl} do
       conn = %Connection{
-        host: 'test.io',
+        host: ~c"test.io",
         port: 22,
         options: [user_interaction: false],
         ref: :sandbox,

--- a/test/sshkit/ssh_test.exs
+++ b/test/sshkit/ssh_test.exs
@@ -22,9 +22,9 @@ defmodule SSHKit.SSHTest do
     test "opens a connection with the given options and keeps it open", %{impl: impl} do
       impl
       |> expect(:connect, fn host, port, opts, timeout ->
-        assert host == 'test.io'
+        assert host == ~c"test.io"
         assert port == 2222
-        assert opts == [user_interaction: false, user: 'me']
+        assert opts == [user_interaction: false, user: ~c"me"]
         assert timeout == :infinity
         {:ok, :connection_ref}
       end)
@@ -32,8 +32,8 @@ defmodule SSHKit.SSHTest do
       {:ok, conn} = connect(@host, user: @user, port: 2222, impl: impl)
 
       assert conn == %Connection{
-               host: 'test.io',
-               options: [user_interaction: false, user: 'me'],
+               host: ~c"test.io",
+               options: [user_interaction: false, user: ~c"me"],
                port: 2222,
                ref: :connection_ref,
                impl: impl
@@ -99,7 +99,7 @@ defmodule SSHKit.SSHTest do
 
     test "closes the connection", %{impl: impl} do
       conn = %SSHKit.SSH.Connection{
-        host: 'test.io',
+        host: ~c"test.io",
         port: 22,
         options: [user_interaction: false],
         ref: :connection_ref,
@@ -125,7 +125,7 @@ defmodule SSHKit.SSHTest do
     test "captures output and exit status by default", %{conn: conn, impl: impl} do
       impl
       |> expect(:session_channel, fn :cref, _, _, :infinity -> {:ok, 11} end)
-      |> expect(:exec, fn :cref, 11, 'try', :infinity -> :success end)
+      |> expect(:exec, fn :cref, 11, ~c"try", :infinity -> :success end)
       |> expect(:adjust_window, 2, fn :cref, 11, _ -> :ok end)
 
       send(self(), {:ssh_cm, conn.ref, {:data, 11, 0, "out"}})
@@ -139,7 +139,7 @@ defmodule SSHKit.SSHTest do
     test "accepts a custom handler function and accumulator", %{conn: conn, impl: impl} do
       impl
       |> expect(:session_channel, fn :cref, _, _, _ -> {:ok, 31} end)
-      |> expect(:exec, fn :cref, 31, 'cmd', _ -> :success end)
+      |> expect(:exec, fn :cref, 31, ~c"cmd", _ -> :success end)
       |> expect(:send, fn :cref, 31, 0, "PING", _ -> :ok end)
       |> expect(:adjust_window, fn :cref, 31, _ -> :ok end)
       |> expect(:close, fn :cref, 31 -> :ok end)

--- a/test/sshkit/utils_test.exs
+++ b/test/sshkit/utils_test.exs
@@ -5,24 +5,24 @@ defmodule SSHKit.UtilsTest do
 
   describe "charlistify/1" do
     test "converts binaries to char lists" do
-      assert Utils.charlistify("sshkit") == 'sshkit'
+      assert Utils.charlistify("sshkit") == ~c"sshkit"
     end
 
     test "converts binaries in tuples" do
-      assert Utils.charlistify({:user, "me"}) == {:user, 'me'}
+      assert Utils.charlistify({:user, "me"}) == {:user, ~c"me"}
     end
 
     test "converts binaries in lists" do
-      assert Utils.charlistify(["ssh-rsa", "ssh-dss"]) == ['ssh-rsa', 'ssh-dss']
+      assert Utils.charlistify(["ssh-rsa", "ssh-dss"]) == [~c"ssh-rsa", ~c"ssh-dss"]
     end
 
     test "converts binaries in keywords" do
-      assert Utils.charlistify(inet: :inet6, user: "me") == [inet: :inet6, user: 'me']
+      assert Utils.charlistify(inet: :inet6, user: "me") == [inet: :inet6, user: ~c"me"]
     end
 
     test "converts binaries in nested lists" do
       actual = Utils.charlistify(pref_public_key_algs: ["ssh-rsa", "ssh-dss"])
-      expected = [pref_public_key_algs: ['ssh-rsa', 'ssh-dss']]
+      expected = [pref_public_key_algs: [~c"ssh-rsa", ~c"ssh-dss"]]
       assert actual == expected
     end
 


### PR DESCRIPTION
### Description

Compilation (before this PR) of the library generates a lot of warnings on Elixir 1.17+:

```
     warning: using single-quoted strings to represent charlists is deprecated.
     Use ~c"" if you indeed want a charlist or use "" instead.
     You may run "mix format --migrate" to change all single-quoted
     strings to use the ~c sigil and fix this warning.
     │
 211 │     '}'
     │     ~
     │
     └─ lib/encode.ex:211:5
```

### Motivation and Context

The goal is to see clearer in remaining warnings & test failures on Elixir 1.18+, as I'm using the library.

### Types of changes

I ran `mix format --migrate` on Elixir 1.18, and kept only the `~c` migration relevant bits.
